### PR TITLE
Adds way_type filter overpass query option to download non-highway da…

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LightOSM"
 uuid = "d1922b25-af4e-4ba3-84af-fe9bea896051"
 authors = ["Jack Chan <jchan2@deloitte.com.au>"]
-version = "0.1.7"
+version = "0.1.8"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -69,7 +69,8 @@ const WAY_EXCLUSION_FILTERS = Dict(
         "area" => ["yes"],
         "highway" => ["proposed", "construction", "abandoned", "platform", "raceway"]
     ),
-    :none => Dict{AbstractString,Vector{AbstractString}}()
+    :none => Dict{AbstractString,Vector{AbstractString}}(),
+    :rail => Dict("highway" => ["proposed", "platform"])
 )
 
 """
@@ -96,14 +97,18 @@ const WAY_FILTERS_QUERY = Dict(
     :bike => """["highway"]$(concatenate_exclusions(WAY_EXCLUSION_FILTERS[:bike]))""",
     :all => """["highway"]$(concatenate_exclusions(WAY_EXCLUSION_FILTERS[:all]))""",
     :all_private => """["highway"]$(concatenate_exclusions(WAY_EXCLUSION_FILTERS[:all_private]))""",
-    :none => """["highway"]$(concatenate_exclusions(WAY_EXCLUSION_FILTERS[:none]))"""
+    :none => """["highway"]$(concatenate_exclusions(WAY_EXCLUSION_FILTERS[:none]))""",
+    :rail => """["railway"]$(concatenate_exclusions(WAY_EXCLUSION_FILTERS[:rail]))"""
 )
 
 """
-OpenStreetMap query strings used for turn restrictions, ignores ["restriction:conditional"] and ["restriction:hgv"].
+OpenStreetMap query strings used for getting relation data in addition to roads & ways
+    for road turn restrictions, ignores ["restriction:conditional"] and ["restriction:hgv"].
 """
 const RELATION_FILTERS_QUERY = Dict(
-    :restriction => """["type"="restriction"]["restriction"][!"conditional"][!"hgv"]"""
+    :default => nothing,
+    :road_turn_restrictions => """["type"="restriction"]["restriction"][!"conditional"][!"hgv"]""",
+    :none => nothing
 )
 
 """


### PR DESCRIPTION
Adds two related but independent features relating to manipulating overpass query strings, that gives users the ability to customise the type of network they want to download using the down:
- Ability to select the way type in the overpass query e.g. Rail, instead of always downloading highways, which was harded in the constant WAY_FILTERS_QUERY
- Ability to pass in a manual set of filters for the overpass query (in a Dict), rather than having to choose from the fixed set as defined by the constant WAY_EXCLUSION_FILTERS

Defaults have been set for the new interfaces, so should be fully backwards compatible.