### PR TITLE
Improve geometry calculation performance

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LightOSM"
 uuid = "d1922b25-af4e-4ba3-84af-fe9bea896051"
 authors = ["Jack Chan <jchan2@deloitte.com.au>"]
-version = "0.1.9"
+version = "0.1.10"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/docs/src/geolocation.md
+++ b/docs/src/geolocation.md
@@ -4,7 +4,6 @@
 distance
 heading
 calculate_location
-LightOSM.to_matrix
 LightOSM.to_cartesian
 LightOSM.bounding_box_from_point
 ```

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -1,7 +1,7 @@
 """
 Approximate radius of the Earth (km) used in geoemetry functions.
 """
-const RADIUS_OF_EARTH_KM = 6371
+const RADIUS_OF_EARTH_KM = 6371.0
 
 """
 Factor used to convert speed from mph to kph units.

--- a/src/geometry.jl
+++ b/src/geometry.jl
@@ -1,102 +1,88 @@
 """
-    to_matrix(locations::Vector{GeoLocation})::Matrix{AbstractFloat}
-
-Converts a vector of GeoLocations to a matrix where the columns are in order of: latitude, longitude, altitude.
-"""
-function to_matrix(locations::Vector{GeoLocation})::Matrix{AbstractFloat}
-    return hcat([[loc.lat, loc.lon, loc.alt] for loc in locations]...)'
-end
-
-"""
-    to_cartesian(location::Vector{GeoLocation})::Matrix{<:AbstractFloat}
+    to_cartesian(lat::T, lon::T, r::T) where {T} 
+    to_cartesian(location::GeoLocation)
+    to_cartesian(locations::Vector{GeoLocation})
 
 Converts a vector of GeoLocations to (x, y, z) cartesian coordinates (based on radius of the Earth).
 """
-function to_cartesian(location::Vector{GeoLocation})::Matrix{<:AbstractFloat}
-    L = to_matrix(location)
-
-    lats = deg2rad.(L[:,1])
-    lons = deg2rad.(L[:,2])
-    alts = L[:,3]
-
-    r = alts .+ RADIUS_OF_EARTH_KM # approximate radius of earth + alt in km
-    x = r .* cos.(lats) .* cos.(lons)
-    y = r .* cos.(lats) .* sin.(lons)
-    z = r .* sin.(lats)
-    return hcat(x, y, z)
+function to_cartesian(lat::T, lon::T, r::T) where {T} 
+    x = r * cos(lat) * cos(lon)
+    y = r * cos(lat) * sin(lon)
+    z = r * sin(lat)
+    return x, y, z
+end
+function to_cartesian(loc::GeoLocation)
+    lat = deg2rad(loc.lat)
+    lon = deg2rad(loc.lon)
+    r = loc.alt + RADIUS_OF_EARTH_KM # approximate radius of earth + alt in km
+    x, y, z = to_cartesian(lat, lon, r)
+    return x, y, z
 end
 
-to_cartesian(location::GeoLocation)::Vector{AbstractFloat} = to_cartesian([location])[1,:]
-
 """
-    haversine(A::Vector{GeoLocation}, B::Vector{GeoLocation})::Vector{AbstractFloat}
+    haversine(a_lat::T, a_lon::T, b_lat::T, b_lon::T) where {T}
+    haversine(GeoLocation, B::GeoLocation)
+    haversine(Node, B::Node)
+    haversine(A::Vector{GeoLocation}, B::Vector{GeoLocation})
+    haversine(A::Vector{Node}, B::Vector{Node})
+    haversine(a::Vector{U}, b::Vector{U})::U where {U <: AbstractFloat}
 
 Calculates the haversine distance (km) between two points.
 """
-function haversine(A::Vector{GeoLocation}, B::Vector{GeoLocation})::Vector{AbstractFloat}
-    A = to_matrix(A)
-    B = to_matrix(B)
 
-    a_lat = deg2rad.(A[:,1])
-    a_lon = deg2rad.(A[:,2])
-    b_lat = deg2rad.(B[:,1])
-    b_lon = deg2rad.(B[:,2])
-    
-    d = sin.((a_lat - b_lat) / 2).^2 + cos.(b_lat) .* cos.(a_lat) .* sin.((a_lon - b_lon) / 2).^2
-    return 2 * RADIUS_OF_EARTH_KM * asin.(sqrt.(d))
+function haversine(a_lat::T, a_lon::T, b_lat::T, b_lon::T) where {T}
+    d = sin((a_lat - b_lat) / 2)^2 + cos(b_lat) * cos(a_lat) * sin((a_lon - b_lon) / 2)^2
+    return 2 * RADIUS_OF_EARTH_KM * asin(sqrt(d))
 end
-
-haversine(a::GeoLocation, b::GeoLocation)::AbstractFloat = haversine([a], [b])[1]
-haversine(A::Vector{<:Node}, B::Vector{<:Node})::Vector{AbstractFloat} = haversine([n.location for n in A], [n.location for n in B])
-haversine(a::Node, b::Node)::AbstractFloat = haversine([a], [b])[1]
-
+function haversine(A::GeoLocation, B::GeoLocation)
+    a_lat = deg2rad(A.lat)
+    a_lon = deg2rad(A.lon)
+    b_lat = deg2rad(B.lat)
+    b_lon = deg2rad(B.lon)
+    return haversine(a_lat, a_lon, b_lat, b_lon)
+end
+haversine(a::Node, b::Node) = haversine(a.location, b.location)
+haversine(A::Vector{<:GeoLocation}, B::Vector{<:GeoLocation}) = haversine.(A, B)
+haversine(A::Vector{<:Node}, B::Vector{<:Node}) = haversine.(A, B)
 function haversine(a::Vector{U}, b::Vector{U})::U where {U <: AbstractFloat}
     a_lat = deg2rad(a[1])
     a_lon = deg2rad(a[2])
     b_lat = deg2rad(b[1])
     b_lon = deg2rad(b[2])
-
-    d = sin((a_lat - b_lat) / 2)^2 + cos(b_lat) * cos(a_lat) * sin((a_lon - b_lon) / 2)^2
-    return 2 * RADIUS_OF_EARTH_KM * asin(sqrt(d))
+    return haversine(a_lat, a_lon, b_lat, b_lon)
 end
 
 """
-    euclidean(A::Vector{GeoLocation}, B::Vector{GeoLocation})::Vector{AbstractFloat}
+    euclidean(a_x::T, a_y::T, a_z::T, b_x::T, b_y::T, b_z::T) where {T}
+    euclidean(A::GeoLocation, B::GeoLocation)
+    euclidean(A::Node, B::Node)
+    euclidean(A::Vector{GeoLocation}, B::Vector{GeoLocation})
+    euclidean(A::Vector{<:Node}, B::Vector{<:Node})
+    euclidean(a::Vector{U}, b::Vector{U})::U where {U <: AbstractFloat}
 
 Calculates the euclidean distance (km) between two points.
 """
-function euclidean(A::Vector{GeoLocation}, B::Vector{GeoLocation})::Vector{AbstractFloat}
-    A = to_cartesian(A)
-    B = to_cartesian(B)
-    return sqrt.(sum.(eachrow((A - B).^2)))
-end
-
-euclidean(a::GeoLocation, b::GeoLocation)::AbstractFloat = euclidean([a], [b])[1]
-euclidean(A::Vector{<:Node}, B::Vector{<:Node})::Vector{AbstractFloat} = euclidean([n.location for n in A], [n.location for n in B])
-euclidean(a::Node, b::Node)::AbstractFloat = euclidean([a], [b])[1]
-
+euclidean(a_x::T, a_y::T, a_z::T, b_x::T, b_y::T, b_z::T) where {T} = hypot(a_x-b_x, a_y-b_y, a_z-b_z)
+euclidean(A::GeoLocation, B::GeoLocation) = euclidean(to_cartesian(A)...,to_cartesian(B)...)
+euclidean(a::Node, b::Node) = euclidean(a.location, b.location)
+euclidean(A::Vector{GeoLocation}, B::Vector{GeoLocation}) = euclidean.(A, B)
+euclidean(A::Vector{<:Node}, B::Vector{<:Node}) = euclidean.(A, B)
 function euclidean(a::Vector{U}, b::Vector{U})::U where {U <: AbstractFloat}
     a_lat = deg2rad(a[1])
     a_lon = deg2rad(a[2])
     b_lat = deg2rad(b[1])
     b_lon = deg2rad(b[2])
-
-    a_x = RADIUS_OF_EARTH_KM * cos(a_lat) * cos(a_lon)
-    a_y = RADIUS_OF_EARTH_KM * cos(a_lat) * sin(a_lon)
-    a_z = RADIUS_OF_EARTH_KM * sin(a_lat)
-
-    b_x = RADIUS_OF_EARTH_KM * cos(b_lat) * cos(b_lon)
-    b_y = RADIUS_OF_EARTH_KM * cos(b_lat) * sin(b_lon)
-    b_z = RADIUS_OF_EARTH_KM * sin(b_lat)
-    
-    return sqrt(sum(([a_x, a_y, a_z] - [b_x, b_y, b_z]).^2))
+    return euclidean(
+        to_cartesian(a_lat, a_lon, RADIUS_OF_EARTH_KM)...,
+        to_cartesian(b_lat, b_lon, RADIUS_OF_EARTH_KM)...
+    )
 end
 
 """
     distance(A::Union{Vector{GeoLocation}, GeoLocation, Vector{<:Node}, Node, Vector{<:AbstractFloat}},
              B::Union{Vector{GeoLocation}, GeoLocation, Vector{<:Node}, Node, Vector{<:AbstractFloat}},
              type::Symbol=:haversine
-             )::Union{Vector{AbstractFloat}, AbstractFloat}
+             )
 
 Calculates the distance (km) between two points or two vectors of points.
 
@@ -106,12 +92,12 @@ Calculates the distance (km) between two points or two vectors of points.
 - `method::Symbol=:haversine`: Either `:haversine` or `:euclidean`.
 
 # Return
-- `Union{Vector{AbstractFloat}, AbstractFloat}`: Distance between origin and destination points in km.
+- Distance between origin and destination points in km.
 """
 function distance(A::Union{Vector{GeoLocation},GeoLocation,Vector{<:Node},Node,Vector{<:AbstractFloat}},
                   B::Union{Vector{GeoLocation},GeoLocation,Vector{<:Node},Node,Vector{<:AbstractFloat}},
                   method::Symbol=:haversine
-                  )::Union{Vector{AbstractFloat},AbstractFloat}
+                  )
     if method == :haversine
         return haversine(A, B)
     elseif method == :euclidean
@@ -122,101 +108,84 @@ function distance(A::Union{Vector{GeoLocation},GeoLocation,Vector{<:Node},Node,V
 end
 
 """
-    heading(A::Vector{GeoLocation}, B::Vector{GeoLocation}, return_units::Symbol=:degrees)::Vector{AbstractFloat}
+    heading(a::GeoLocation, b::GeoLocation, return_units::Symbol=:degrees)
+    heading(a::Node, b::Node, return_units::Symbol=:degrees)
+    heading(A::Vector{GeoLocation}, B::Vector{GeoLocation}, return_units::Symbol=:degrees)
+    heading(A::Vector{Node}, B::Vector{Node}, return_units::Symbol=:degrees)
 
-Calculates headings / bearings between a vector of origin GeoLocations A and vector of destination 
-GeoLocations B. Depending on the `return_units` chosen, the return angle is in range of [-π, π] if `:radians` or 
-[-180, 180] if `:degrees`. Additionally, adjusts destination longitude in case the straight line path between A and B 
-crosses the International Date Line.
+Calculates heading(s) / bearing(s) between two points (`a` is origin, `b` is destination)
+or two vectors of points (`A` is vector of origins, `B` is vector of destinations). Points
+can be either `GeoLocation`s or `Node`s.
 
-# Arguments
-- `A::Vector{GeoLocation}`: Vector of origin GeoLocations.
-- `B::Vector{GeoLocation}`: Vector of destination GeoLocations.
-- `return_units::Symbol=:degrees`: Either `:radians` or `:degrees`.
-
-# Return
-- `Vector{AbstractFloat}`: Vector of headings / bearings in range of [-π, π] if `:radians` or [-180, 180] if `:degrees`.
+Depending on the `return_units` chosen, the return angle is in range of [-π, π] if `:radians`
+or [-180, 180] if `:degrees`. Additionally, adjusts destination longitude in case the straight
+line path between a and b crosses the International Date Line.
 """
-function heading(A::Vector{GeoLocation}, B::Vector{GeoLocation}, return_units::Symbol=:degrees)::Vector{AbstractFloat}
-    A = to_matrix(A)
-    B = to_matrix(B)
 
-    a_lat = A[:,1]
-    a_lon = A[:,2]
-    b_lat = B[:,1]
-    b_lon = B[:,2]
+function heading(a::GeoLocation, b::GeoLocation, return_units::Symbol=:degrees)
+    a_lat = a.lat
+    a_lon = a.lon
+    b_lat = b.lat
+    b_lon = b.lon
 
     # Adjust destination longitude in case straight line path between A and B crosses the International Date Line
-    a_lon_left_idx = (b_lon .<= a_lon) .* ((b_lon .+ 180) .+ (180 .- a_lon) .> (a_lon .- b_lon))
-    a_lon_right_idx = (b_lon .<= a_lon) .* ((b_lon .+ 180) .+ (180 .- a_lon) .<= (a_lon .- b_lon))
+    a_lon_left_idx = (b_lon <= a_lon) * ((b_lon + 180) + (180 - a_lon) > (a_lon - b_lon))
+    a_lon_right_idx = (b_lon <= a_lon) * ((b_lon + 180) + (180 - a_lon) <= (a_lon - b_lon))
 
-    b_lon_left_idx = (b_lon .> a_lon) .* ((a_lon .+ 180) .+ (180 .- b_lon) .< (b_lon .- a_lon))
-    b_lon_right_idx = (b_lon .> a_lon) .* ((a_lon .+ 180) .+ (180 .- b_lon) .>= (b_lon .- a_lon))
+    b_lon_left_idx = (b_lon > a_lon) * ((a_lon + 180) + (180 - b_lon) .< (b_lon - a_lon))
+    b_lon_right_idx = (b_lon > a_lon) * ((a_lon + 180) + (180 - b_lon) >= (b_lon - a_lon))
 
-    b_lon_fixed = b_lon_left_idx .* (-180 .- (180 .- b_lon)) .+
-                  b_lon_right_idx .* b_lon .+
-                  a_lon_left_idx .* b_lon .+
-                  a_lon_right_idx .* (180 .- abs.(-180 .- b_lon))
+    b_lon_fixed = b_lon_left_idx * (-180 - (180 - b_lon)) +
+                  b_lon_right_idx * b_lon +
+                  a_lon_left_idx * b_lon +
+                  a_lon_right_idx * (180 - abs(-180 - b_lon))
 
-    a_lat = deg2rad.(a_lat)
-    a_lon = deg2rad.(a_lon)
-    b_lat = deg2rad.(b_lat)
-    b_lon_fixed = deg2rad.(b_lon_fixed)
+    a_lat = deg2rad(a_lat)
+    a_lon = deg2rad(a_lon)
+    b_lat = deg2rad(b_lat)
+    b_lon_fixed = deg2rad(b_lon_fixed)
 
-    y = sin.(b_lon_fixed - a_lon) .* cos.(b_lat)
-    x = cos.(a_lat) .* sin.(b_lat) .- sin.(a_lat) .* cos.(b_lat) .* cos.(b_lon_fixed - a_lon)
+    y = sin(b_lon_fixed - a_lon) * cos(b_lat)
+    x = cos(a_lat) * sin(b_lat) - sin(a_lat) * cos(b_lat) * cos(b_lon_fixed - a_lon)
     
     heading = atan.(y, x)
 
     if return_units == :radians
         return heading
     elseif return_units == :degrees
-        return rad2deg.(heading)
+        return rad2deg(heading)
     else
         throw(ErrorException("Incorrect input for argument `return_units`, choose either `:degrees` or `:radians`"))
+    end
 end
-end
-
-heading(a::GeoLocation, b::GeoLocation, return_units::Symbol=:degrees)::AbstractFloat = heading([a], [b], return_units)[1]
-heading(A::Vector{<:Node}, B::Vector{<:Node})::Vector{AbstractFloat} = heading([n.location for n in A], [n.location for n in B])
-heading(a::Node, b::Node)::AbstractFloat = heading([a], [b])[1]
+heading(A::Vector{GeoLocation}, B::Vector{GeoLocation}, return_units::Symbol=:degrees) = heading.(A, B, return_units)
+heading(a::Node, b::Node, return_units::Symbol=:degrees)::AbstractFloat = heading(a.location, b.location, return_units)
+heading(A::Vector{<:Node}, B::Vector{<:Node}, return_units::Symbol=:degrees) = heading.(A, B, return_units)
 
 """
-    calculate_location(lats::Vector{<:Number},
-                       lons::Vector{<:Number},
-                       headings::Vector{<:Number},
-                       distances::Vector{<:Number}
-                       )::Vector{NamedTuple}
+    calculate_location(origin::GeoLocation, heading::Number, distance::Number)
+    calculate_location(origin::Node, heading::Number, distance::Number)
+    calculate_location(origin::Vector{GeoLocation}, heading::Vector{<:Number}, distance::Vector{<:Number})
+    calculate_location(origin::Vector{Node}, heading::Vector{<:Number}, distance::Vector{<:Number})
 
-Calculates next location given origin Geolocations (lats, lons), headings (degrees) and distances (km).
+Calculates next location(s) given origin `GeoLocation`(s) or `Node`(s), heading(s) (degrees)
+and distance(s) (km).
 
-# Arguments
-- `origins::Vector{GeoLocation}`: Vector of origin GeoLocations (lats, lons).
-- `headings::Vector{<:Number}`: Vector of headings to next location (degrees).
-- `distances::Vector{<:Number}`: Vector of distances to next location (km).
-
-# Return
-- `Vector{GeoLocation}`: Vector of GeoLocations (lats, lons) of next locations.
+Locations are returned as `GeoLocation`s.
 """
-function calculate_location(origins::Vector{GeoLocation},
-                            headings::Vector{<:Number},
-                            distances::Vector{<:Number}
-                            )::Vector{GeoLocation}
-    origins = to_matrix(origins)
+function calculate_location(origin::GeoLocation, heading::Number, distance::Number)
+    lat = deg2rad(origin.lat)
+    lon = deg2rad(origin.lon)
+    heading = deg2rad(heading)
 
-    lats = deg2rad.(origins[:,1])
-    lons = deg2rad.(origins[:,2])
-    headings = deg2rad.(headings)
+    lat_final = asin(sin(lat) * cos(distance / RADIUS_OF_EARTH_KM) + cos(lat) * sin(distance / RADIUS_OF_EARTH_KM) * cos(heading))
+    lon_final = lon + atan(sin(heading) * sin(distance / RADIUS_OF_EARTH_KM) * cos(lat), cos(distance / RADIUS_OF_EARTH_KM) - sin(lat) * sin(lat_final))
 
-    lats_final = asin.(sin.(lats) .* cos.(distances / RADIUS_OF_EARTH_KM) + cos.(lats) .* sin.(distances / RADIUS_OF_EARTH_KM) .* cos.(headings))
-    lons_final = lons .+ atan.(sin.(headings) .* sin.(distances / RADIUS_OF_EARTH_KM) .* cos.(lats), cos.(distances / RADIUS_OF_EARTH_KM) - sin.(lats) .* sin.(lats_final))
-    
-    return GeoLocation([[loc...] for loc in zip(rad2deg.(lats_final), rad2deg.(lons_final))])
+    return GeoLocation(rad2deg(lat_final), rad2deg(lon_final))
 end
-
-calculate_location(origin::GeoLocation, heading::Number, distance::Number)::GeoLocation = calculate_location([origin], [heading], [distance])[1]
-calculate_location(origin::Vector{<:Node}, heading::Vector{<:Number}, distance::Vector{<:Number})::Vector{GeoLocation} = calculate_location([n.location for n in origin], heading, distance)
-calculate_location(origin::Node, heading::Number, distance::Number)::GeoLocation = calculate_location([origin], [heading], [distance])[1]
+calculate_location(origins::Vector{GeoLocation}, headings::Vector{<:Number}, distances::Vector{<:Number}) = calculate_location.(origins, headings, distances)
+calculate_location(origin::Node, heading::Number, distance::Number)::GeoLocation = calculate_location(origin.location, heading, distance)
+calculate_location(origins::Vector{<:Node}, headings::Vector{<:Number}, distances::Vector{<:Number}) = calculate_location.(origins, headings, distances)
 
 """
     bounding_box_from_point(point::GeoLocation, radius::Number)::NamedTuple

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,19 +1,29 @@
 """
 Representation of a geospatial coordinates.
 
-- `lat::AbstractFloat`: Latitude.
-- `lon::AbstractFloat`: Longitude.
-- `alt::AbstractFloat`: Altitude.
+- `lat::Float64`: Latitude.
+- `lon::Float64`: Longitude.
+- `alt::Float64`: Altitude.
 """
 @with_kw struct GeoLocation
-    lat::AbstractFloat
-    lon::AbstractFloat
-    alt::AbstractFloat = 0.0
+    lat::Float64
+    lon::Float64
+    alt::Float64 = 0.0
 end
 
 GeoLocation(lat::AbstractFloat, lon::AbstractFloat)::GeoLocation = GeoLocation(lat=lat, lon=lon)
 GeoLocation(point::Vector{<:AbstractFloat})::GeoLocation = GeoLocation(point...)
 GeoLocation(point_vector::Vector{<:Vector{<:AbstractFloat}})::Vector{GeoLocation} = [GeoLocation(p...) for p in point_vector]
+
+function Base.:(==)(loc1::GeoLocation, loc2::GeoLocation)
+    return loc1.lat == loc2.lat && loc1.lon == loc2.lon && loc1.alt == loc2.alt
+end
+function Base.hash(loc::GeoLocation, h::UInt)
+    for field in fieldnames(GeoLocation)
+		h = hash(getproperty(loc, field), h)
+	end
+    return h
+end
 
 """
 OpenStreetMap node.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,26 +5,55 @@ using Test
 Utility tests.
 """
 
-a = GeoLocation(-33.8308, 151.223, 0.0)
-A = [GeoLocation(-33.8308, 151.223, 0.0), GeoLocation(-33.8293, 151.221, 0.0)]
-b = GeoLocation(-33.8294, 151.22, 0.0)
-B = [GeoLocation(-33.8294, 151.22, 0.0), GeoLocation(-33.8301, 151.22, 0.0)]
+a1 = GeoLocation(-33.8308, 151.223, 0.0)
+a2 = GeoLocation(-33.8293, 151.221, 0.0)
+A = [a1, a2]
+b1 = GeoLocation(-33.8294, 150.22, 0.0)
+b2 = GeoLocation(-33.8301, 151.22, 0.0)
+B = [b1, b2]
+node_a1 = Node(1,a1,nothing)
+node_a2 = Node(1,a2,nothing)
+node_b1 = Node(1,b1,nothing)
+node_b2 = Node(1,b2,nothing)
 
 @testset "Distance tests" begin
-    @test abs(LightOSM.euclidean(a, b) - 0.318) < 0.01
-    @test sum(abs.(LightOSM.euclidean(A, B) - [0.318, 0.128])) < 0.1
-    @test abs(LightOSM.haversine(a, b) - 0.318) < 0.01
-    @test sum(abs.(LightOSM.haversine(A, B) - [0.318, 0.128])) < 0.1
+    @test isapprox(LightOSM.euclidean(a1, b1), 92.6448020780204)
+    @test all(isapprox.(LightOSM.euclidean(A, B), [92.6448020780204, 0.1282389369277561]))
+    @test isapprox(LightOSM.haversine(a1, b1), 92.64561837286445)
+    @test all(isapprox.(LightOSM.haversine(A, B), [92.64561837286445, 0.1282389369295829]))
+    @test LightOSM.euclidean(a1, b1) == LightOSM.euclidean(node_a1, node_b1)
+    @test LightOSM.euclidean(A, B) == LightOSM.euclidean([node_a1, node_a2], [node_b1, node_b2])
+    @test LightOSM.haversine(a1, b1) == LightOSM.haversine(node_a1, node_b1)
+    @test LightOSM.haversine(A, B) == LightOSM.haversine([node_a1, node_a2], [node_b1, node_b2])
+    @test LightOSM.euclidean([a1.lat, a1.lon], [b1.lat, b1.lon]) == LightOSM.euclidean(node_a1, node_b1)
+    @test LightOSM.haversine([a1.lat, a1.lon], [b1.lat, b1.lon]) == LightOSM.haversine(node_a1, node_b1)
 
-    @test abs(distance(a, b, :haversine) - 0.318) < 0.01
-    @test abs(distance(a, b, :euclidean) - 0.318) < 0.01
-    @test sum(abs.(distance(A, B, :haversine) - [0.318, 0.128])) < 0.01
-    @test sum(abs.(distance(A, B, :euclidean) - [0.318, 0.128])) < 0.01
+    @test isapprox(distance(a1, b1, :euclidean), 92.6448020780204)
+    @test isapprox(distance(a1, b1, :haversine), 92.64561837286445)
+    @test all(isapprox.(distance(A, B, :euclidean), [92.6448020780204, 0.1282389369277561]))
+    @test all(isapprox.(distance(A, B, :haversine), [92.64561837286445, 0.1282389369295829]))
 end
 
 @testset "Heading tests" begin
+    a = GeoLocation(-33.8308, 151.223, 0.0)
+    b = GeoLocation(-33.8294, 151.22, 0.0)
     # Used http://instantglobe.com/CRANES/GeoCoordTool.html to manually calculate headings and distance
     # Note: heading function returns bearings in range of [-180, 180], to convert to [0, 360] scale we need to adjust by (θ + 360) % 360
     @test abs((heading(a, b, :degrees) + 360) % 360 - 299.32559505087795) < 0.01
     @test sum((abs.(heading(A, B, :degrees) .+ 360) .% 360 - [299.32559505087795, 226.07812206538435])) < 0.01
+end
+
+@testset "calculate_location tests" begin
+    a = GeoLocation(-33.8308, 151.223, 0.0)
+    b = GeoLocation(-33.8294, 151.22, 0.0)
+    dist_a = 100.0
+    dist_b = 100.0
+    heading_a = 10.0
+    heading_b = 10.0
+    end_a = calculate_location(a, heading_a, dist_a)
+    @test isapprox(end_a.lat, -32.945001009035984)
+    @test isapprox(end_a.lon, 151.40908284685628)
+    @test isapprox(end_a.alt, 0.0)
+    ends = calculate_location([a, b], [heading_a, heading_b], [dist_a, dist_b])
+    @test ends[1] == end_a
 end


### PR DESCRIPTION
Changes to geometry calculations to improve performance:

- Change behaviour so that rather than the non vector arguments being put into vectors, the default calculation is done with scalars. If vectors are inputted, the default calculation is broadcasted
- Make `RADIUS_OF_EARTH_KM` a `Float64` to remove type conversion
- Added tests to check no change in output
- Updated doc strings
- Removed now unused `to_matrix`

Examples of performance improvement
```Julia
a = GeoLocation(-33.8308, 151.223, 0.0)
b = GeoLocation(-33.8294, 151.22, 0.0)
a1 = GeoLocation(-33.8308, 151.223, 0.0)
a2 = GeoLocation(-33.8293, 151.221, 0.0)
A = [a1, a2]
b1 = GeoLocation(-33.8294, 150.22, 0.0)
b2 = GeoLocation(-33.8301, 151.22, 0.0)
B = [b1, b2]

# Before
julia> @btime heading(a, b, :degrees)
  17.625 μs (190 allocations: 9.53 KiB)
-60.67440494904522

# After
julia> @btime heading(a, b, :degrees)
  65.287 ns (0 allocations: 0 bytes)
 -60.67440494904522

# Before
julia> @btime heading(A, B, :degrees)
  18.916 μs (228 allocations: 10.22 KiB)
2-element Vector{AbstractFloat}:
  -90.18293447266345
  -133.92187793446274

# After
 julia> @btime heading(A, B, :degrees)
  165.349 ns (1 allocation: 96 bytes)
2-element Vector{Float64}:
  -90.18293447266345
  -133.92187793446274

# Before
 julia> @btime calculate_location($a, $heading_a, $dist_a)
  8.764 μs (96 allocations: 4.69 KiB)
GeoLocation
  lat: Float64 -32.945001009035984
  lon: Float64 151.40908284685628
  alt: Float64 0.0

# After
 julia> @btime calculate_location($a, $heading_a, $dist_a)
  84.936 ns (0 allocations: 0 bytes)
GeoLocation
  lat: Float64 -32.945001009035984
  lon: Float64 151.40908284685628
  alt: Float64 0.0
```