### PR TITLE
Add back in `to_cartesian(Vector{GeoLocation})` but flip output

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LightOSM"
 uuid = "d1922b25-af4e-4ba3-84af-fe9bea896051"
 authors = ["Jack Chan <jchan2@deloitte.com.au>"]
-version = "0.1.10"
+version = "0.1.11"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/geometry.jl
+++ b/src/geometry.jl
@@ -18,6 +18,17 @@ function to_cartesian(loc::GeoLocation)
     x, y, z = to_cartesian(lat, lon, r)
     return x, y, z
 end
+function to_cartesian(locs::Vector{GeoLocation})
+    n_points = length(locs)
+    results = Matrix{Float64}(undef, 3, n_points)
+    @inbounds for i in 1:n_points
+        x, y, z = to_cartesian(locs[i])
+        results[1, i] = x
+        results[2, i] = y
+        results[3, i] = z
+    end
+    return results
+end
 
 """
     haversine(a_lat::T, a_lon::T, b_lat::T, b_lon::T) where {T}

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -438,6 +438,6 @@ Adds KDTree to `OSMGraph` for finding nearest neighbours.
 """
 function add_kdtree!(g::OSMGraph)
     node_locations = [node.location for (id, node) in g.nodes]  # node locations must have the same order as node indices
-    cartesian_locations = transpose(to_cartesian(node_locations))
+    cartesian_locations = to_cartesian(node_locations)
     g.kdtree = KDTree(cartesian_locations)
 end


### PR DESCRIPTION
Previous commit and release removed the method that is used in `add_kdtree!`

As this method of `to_cartesian` is only used in `add_kdtree!`, remove the need for `transpose` by formatting the output how we want