### PR TITLE
Graph loading speed improvements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LightOSM"
 uuid = "d1922b25-af4e-4ba3-84af-fe9bea896051"
 authors = ["Jack Chan <jchan2@deloitte.com.au>"]
-version = "0.1.11"
+version = "0.1.12"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/buildings.jl
+++ b/src/buildings.jl
@@ -193,7 +193,7 @@ function height(tags::Dict)::Number
 end
 
 function parse_osm_buildings_dict(osm_buildings_dict::AbstractDict)::Dict{Integer,Building}
-    T = DEFAULT_DATA_TYPES[:OSM_ID]
+    T = DEFAULT_OSM_ID_TYPE
     
     nodes = Dict{T,Node{T}}()
     for node in osm_buildings_dict["node"]

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -190,19 +190,17 @@ const LANE_EFFICIENCY = Dict(
     1 => 0.7,
     2 => 0.8,
     3 => 0.9,
-    4 => 1
+    4 => 1.0
 )
 
 """
 Default data types used to construct OSMGraph object.
 """
-const DEFAULT_DATA_TYPES = Dict(
-    :OSM_ID => Int64, # default osm node/highway id date type
-    :OSM_INDEX => Int32, # default osm node index data type
-    :OSM_EDGE_WEIGHT => Float64, # default osm edge weight data type
-    :OSM_MAXSPEED => Int16, # default osm maxspeed data type
-    :OSM_LANES => Int8, # default osm lanes data type
-)
+const DEFAULT_OSM_ID_TYPE = Int64
+const DEFAULT_OSM_INDEX_TYPE = Int32
+const DEFAULT_OSM_EDGE_WEIGHT_TYPE = Float64
+const DEFAULT_OSM_MAXSPEED_TYPE = Int16
+const DEFAULT_OSM_LANES_TYPE = Int8
 
 """
 Default height of buildings in metres.

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -1,9 +1,9 @@
 """
 Determine road maxspeeds given osm way tags dictionary.
 """
-function maxspeed(tags::AbstractDict)::Integer
+function maxspeed(tags::AbstractDict)::DEFAULT_OSM_MAXSPEED_TYPE
     maxspeed = get(tags, "maxspeed", "default")
-    U = DEFAULT_DATA_TYPES[:OSM_MAXSPEED]
+    U = DEFAULT_OSM_MAXSPEED_TYPE
 
     if maxspeed != "default"
         if maxspeed isa Integer
@@ -37,9 +37,9 @@ end
 """
 Determine number of lanes given osm way tags dictionary.
 """
-function lanes(tags::AbstractDict)::Integer
+function lanes(tags::AbstractDict)::DEFAULT_OSM_LANES_TYPE
     lanes = get(tags, "lanes", "default")
-    U = DEFAULT_DATA_TYPES[:OSM_LANES]
+    U = DEFAULT_OSM_LANES_TYPE
 
     if lanes != "default"
         if lanes isa Integer
@@ -125,7 +125,7 @@ Determine if a restriction is valid and has usable data.
 function is_valid_restriction(members::AbstractArray, highways::AbstractDict{T,Way{T}})::Bool where T <: Integer
     role_counts = DefaultDict(0)
     role_type_counts = DefaultDict(0)
-    ways_set = Set{Integer}()
+    ways_set = Set{Int}()
     ways_mapping = DefaultDict(Vector)
     via_node = nothing
 
@@ -198,12 +198,12 @@ end
 Parse OpenStreetMap data into `Node`, `Way` and `Restriction` objects.
 """
 function parse_osm_network_dict(osm_network_dict::AbstractDict, network_type::Symbol=:drive)::OSMGraph
-    U = DEFAULT_DATA_TYPES[:OSM_INDEX]
-    T = DEFAULT_DATA_TYPES[:OSM_ID]
-    W = DEFAULT_DATA_TYPES[:OSM_EDGE_WEIGHT]
+    U = DEFAULT_OSM_INDEX_TYPE
+    T = DEFAULT_OSM_ID_TYPE
+    W = DEFAULT_OSM_EDGE_WEIGHT_TYPE
     
     highways = Dict{T,Way{T}}()
-    highway_nodes = Set{Integer}([])
+    highway_nodes = Set{Int}([])
     for way in osm_network_dict["way"]
         if haskey(way, "tags") && haskey(way, "nodes")
             tags = way["tags"]
@@ -288,18 +288,18 @@ function parse_xml_dict_to_json_dict(dict::AbstractDict)::AbstractDict
     for (type, elements) in dict
         for (i, el) in enumerate(elements)
             !(el isa AbstractDict) && continue
-
-            if haskey(el, "tag")
-                dict[type][i]["tags"] = Dict{String,Any}(tag["k"] => tag["v"] for tag in el["tag"] if tag["k"] isa String)
+            sub_dict::Dict{String, Any} = el
+            if haskey(sub_dict, "tag")
+                dict[type][i]["tags"] = Dict{String,Any}(tag["k"] => tag["v"] for tag in sub_dict["tag"] if tag["k"] isa String)
                 delete!(dict[type][i], "tag")
             end
 
-            if haskey(el, "member")
+            if haskey(sub_dict, "member")
                 dict[type][i]["members"] = pop!(dict[type][i], "member") # rename
             end
 
-            if haskey(el, "nd")
-                dict[type][i]["nodes"] = [nd["ref"] for nd in el["nd"]]
+            if haskey(sub_dict, "nd")
+                dict[type][i]["nodes"] = [nd["ref"] for nd in sub_dict["nd"]]
                 delete!(dict[type][i], "nd")
             end
         end

--- a/src/types.jl
+++ b/src/types.jl
@@ -36,7 +36,7 @@ OpenStreetMap node.
 struct Node{T <: Integer}
     id::T
     location::GeoLocation
-    tags::Union{AbstractDict{String,Any},Nothing}
+    tags::Union{Dict{String,Any},Nothing}
 end
 
 """
@@ -50,7 +50,7 @@ OpenStreetMap way.
 struct Way{T <: Integer}
     id::T
     nodes::Vector{T}
-    tags::AbstractDict{String,Any}
+    tags::Dict{String,Any}
 end
 
 """
@@ -70,7 +70,7 @@ OpenStreetMap turn restriction (relation).
 @with_kw struct Restriction{T <: Integer}
     id::T
     type::String
-    tags::AbstractDict{String,Any}
+    tags::Dict{String,Any}
     from_way::T
     to_way::T
     via_node::Union{T,Nothing} = nothing
@@ -83,15 +83,15 @@ end
 Container for storing OpenStreetMap node, way, relation and graph related obejcts.
 
 `U <: Integer,T <: Integer,W <: Real`
-- `nodes::AbstractDict{T,Node{T}}`: Mapping of node ids to node objects.
+- `nodes::Dict{T,Node{T}}`: Mapping of node ids to node objects.
 - `node_coordinates::Vector{Vector{W}}`: Vector of node coordinates [[lat, lon]...], indexed by graph vertices.
-- `highways::AbstractDict{T,Way{T}}`: Mapping of way ids to way objects.
-- `node_to_index::AbstractDict{T,U}`: Mapping of node ids to graph vertices.
-- `index_to_node::AbstractDict{U,T}`: Mapping of graph vertices to node ids.
-- `node_to_highway::AbstractDict{T,Vector{T}}`: Mapping of node ids to vector of way ids.
-- `edge_to_highway::AbstractDict{Vector{T},T}`: Mapping of edges (adjacent node pairs) to way ids.
-- `restrictions::AbstractDict{T,Restriction{T}}`: Mapping of relation ids to restriction objects.
-- `indexed_restrictions::Union{AbstractDict{U,Vector{MutableLinkedList{U}}},Nothing}`: Mapping of via node ids to ordered sequences of restricted node ids.
+- `highways::Dict{T,Way{T}}`: Mapping of way ids to way objects.
+- `node_to_index::OrderedDict{T,U}`: Mapping of node ids to graph vertices.
+- `index_to_node::OrderedDict{U,T}`: Mapping of graph vertices to node ids.
+- `node_to_highway::Dict{T,Vector{T}}`: Mapping of node ids to vector of way ids.
+- `edge_to_highway::Dict{Vector{T},T}`: Mapping of edges (adjacent node pairs) to way ids.
+- `restrictions::Dict{T,Restriction{T}}`: Mapping of relation ids to restriction objects.
+- `indexed_restrictions::Union{DefaultDict{U,Vector{MutableLinkedList{U}}},Nothing}`: Mapping of via node ids to ordered sequences of restricted node ids.
 - `graph::Union{AbstractGraph,Nothing}`: Either DiGraph, StaticDiGraph, SimpleWeightedDiGraph or MetaDiGraph.
 - `weights::Union{SparseMatrixCSC{W,U},Nothing}`: Sparse adjacency matrix (weights between graph vertices), either `:distance` (km), `:time` (hours) or `:lane_efficiency` (time scaled by number of lanes).
 - `dijkstra_states::Vector{Vector{U}}`: Vector of dijkstra parent states indexed by source vertices, used to retrieve shortest path from source vertex to any other vertex.
@@ -104,10 +104,10 @@ Container for storing OpenStreetMap node, way, relation and graph related obejct
     highways::Dict{T,Way{T}} = Dict{T,Way{T}}()
     node_to_index::OrderedDict{T,U} = OrderedDict{T,U}()
     index_to_node::OrderedDict{U,T} = OrderedDict{U,T}()
-    node_to_highway::DefaultDict{T,Vector{T}} = DefaultDict{T,Vector{T}}(Vector{T})
+    node_to_highway::Dict{T,Vector{T}} = Dict{T,Vector{T}}()
     edge_to_highway::Dict{Vector{T},T} = Dict{Vector{T},T}()
     restrictions::Dict{T,Restriction{T}} = Dict{T,Restriction{T}}()
-    indexed_restrictions::Union{AbstractDict{U,Vector{MutableLinkedList{U}}},Nothing} = nothing
+    indexed_restrictions::Union{DefaultDict{U,Vector{MutableLinkedList{U}}},Nothing} = nothing
     graph::Union{AbstractGraph,Nothing} = nothing
     weights::Union{SparseMatrixCSC{W,U},Nothing} = nothing
     dijkstra_states::Union{Vector{Vector{U}},Nothing} = nothing

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -101,7 +101,7 @@ Parses a LightXML object to a dictionary.
 - `AbstractDict`: XML parsed as a dictionary.
 """
 function xml_to_dict(root_node::Union{XMLNode,XMLElement}, attributes_to_exclude::Set=Set())::AbstractDict
-    result = Dict()
+    result = Dict{String, Any}()
 
     for a in attributes(root_node)
         if !(name(a) in attributes_to_exclude)
@@ -110,7 +110,7 @@ function xml_to_dict(root_node::Union{XMLNode,XMLElement}, attributes_to_exclude
     end
 
     if has_children(root_node)
-        for c in collect(child_elements(root_node))
+        for c in child_elements(root_node)
             key = name(c)
 
             if key in attributes_to_exclude
@@ -118,7 +118,7 @@ function xml_to_dict(root_node::Union{XMLNode,XMLElement}, attributes_to_exclude
             end
 
             if haskey(result, name(c))
-                push!(result[key], xml_to_dict(c, attributes_to_exclude))
+                push!(result[key]::Vector{Dict{String, Any}}, xml_to_dict(c, attributes_to_exclude))
             else
                 result[key] = [xml_to_dict(c, attributes_to_exclude)]
             end
@@ -161,7 +161,8 @@ end
 """
 Joins an array of arrays into a single array, on common trailing elements.
 """
-function join_arrays_on_common_trailing_elements(arrays::AbstractArray{T}...)::AbstractArray{T} where T <: Any
+function join_arrays_on_common_trailing_elements(arrays::AbstractVector{T}...)::AbstractVector{T} where T <: Any
+    # Can we make this type stable? IE for input of Vector{Vector{Int}} a return of Vector{Int} can be detected by @code_warntype
     current = arrays[1]
     others = setdiff(arrays, [current])
 


### PR DESCRIPTION
This could do with a bit of testing I think, to check nothing has changed (unit tests will sadly only catch some of it as present).

On my machine, loading machine of the graph in the tutorial reduces by >3 times.

Changes include:

- Making abstract typing concrete
- Changing how default OSM types are set
- Removing allocations where possible
- Using `@inbounds` (not much effect)
- Type annotation to minimise runtime dispatch

It looks like parsing the xml is now greater than half of the time to load, we could investigate some sort of caching for future gains