### PR TITLE
A few updates to file handling

### DIFF
--- a/src/buildings.jl
+++ b/src/buildings.jl
@@ -296,9 +296,8 @@ Creates `Building` objects from OpenStreetMap data file (either `:osm`, `:xml` o
 - `Dict{Integer,Building}`: Mapping from building relation/way ids to `Building` objects.
 """
 function buildings_from_file(file_path::String)::Dict{Integer,Building}
-    !isfile(file_path) && throw(ErrorException("Buildings file $file_path does not exist"))
-    extension = split(file_path, '.')[end]
-    deserializer = file_deserializer(Symbol(extension))
+    !isfile(file_path) && throw(ArgumentError("File $file_path does not exist"))
+    deserializer = file_deserializer(file_path)
     obj = deserializer(file_path)
     return buildings_from_object(obj)
 end

--- a/src/buildings.jl
+++ b/src/buildings.jl
@@ -156,16 +156,8 @@ function download_osm_buildings(download_method::Symbol;
     @info "Downloaded osm buildings data from $(["$k: $v" for (k, v) in download_kwargs]) in $download_format format"
 
     if !(save_to_file_location isa Nothing)
-        file_extension = "." * String(download_format)
-
-        if !occursin(file_extension, save_to_file_location)
-            save_to_file_location *= file_extension
-        end
-
-        open(save_to_file_location, "w") do io
-            write(io, data)
-        end
-
+        save_to_file_location = validate_save_location(save_to_file_location, download_format)
+        write(save_to_file_location, data)
         @info "Saved osm buildings data to disk: $save_to_file_location"
     end
 

--- a/src/buildings.jl
+++ b/src/buildings.jl
@@ -13,7 +13,7 @@ function overpass_polygon_buildings_query(geojson_polygons::Vector{Vector{Any}},
 end
 
 """
-    osm_network_from_place_name(;place_name::String,
+    osm_buildings_from_place_name(;place_name::String,
                                 metadata::Bool=false,
                                 download_format::Symbol=:osm
                                 )::String
@@ -38,7 +38,7 @@ function osm_buildings_from_place_name(;place_name::String,
 end
 
 """
-    osm_network_from_bbox(;minlat::AbstractFloat,
+    osm_buildings_from_bbox(;minlat::AbstractFloat,
                           minlon::AbstractFloat,
                           maxlat::AbstractFloat,
                           maxlon::AbstractFloat,
@@ -73,7 +73,7 @@ function osm_buildings_from_bbox(;minlat::Float64,
 end
 
 """
-    osm_network_from_point(;point::GeoLocation,
+    osm_buildings_from_point(;point::GeoLocation,
                            radius::Number,
                            metadata::Bool=false,
                            download_format::Symbol=:osm

--- a/src/download.jl
+++ b/src/download.jl
@@ -400,16 +400,8 @@ function download_osm_network(download_method::Symbol;
     @info "Downloaded osm network data from $(["$k: $v" for (k, v) in download_kwargs]) in $download_format format"
 
     if !(save_to_file_location isa Nothing)
-        file_extension = "." * String(download_format)
-
-        if !occursin(file_extension, save_to_file_location)
-            save_to_file_location *= file_extension
-        end
-
-        open(save_to_file_location, "w") do io
-            write(io, data)
-        end
-
+        save_to_file_location = validate_save_location(save_to_file_location, download_format)
+        write(save_to_file_location, data)
         @info "Saved osm network data to disk: $save_to_file_location"
     end
 

--- a/src/download.jl
+++ b/src/download.jl
@@ -74,7 +74,7 @@ end
 """
     overpass_query(filters::String,
                    metadata::Bool=false,
-                   download_format::Symbol=:osm,
+                   download_format::Symbol=:json,
                    bbox::Union{Vector{AbstractFloat},Nothing}=nothing
                    )::String
 
@@ -83,7 +83,7 @@ Forms an Overpass query string. For a guide on the OSM query language, see https
 # Arguments
 - `filters::String`: Filters for the query, e.g. polygon filter, highways only, traffic lights only, etc.
 - `metadata::Bool=false`: Set true to return metadata.
-- `download_format::Symbol=:osm`: Download format, either `:osm`, `:xml` or `json`.
+- `download_format::Symbol=:json`: Download format, either `:osm`, `:xml` or `json`.
 - `bbox::Union{Vector{AbstractFloat},Nothing}=nothing`: Optional bounding box filter.
 
 # Return
@@ -91,7 +91,7 @@ Forms an Overpass query string. For a guide on the OSM query language, see https
 """
 function overpass_query(filters::String,
                         metadata::Bool=false,
-                        download_format::Symbol=:osm,
+                        download_format::Symbol=:json,
                         bbox::Union{Vector{<:AbstractFloat},Nothing}=nothing
                         )::String
     download_format_str = """[out:$(OSM_DOWNLOAD_FORMAT[download_format])]"""
@@ -106,7 +106,7 @@ end
     overpass_polygon_network_query(geojson_polygons::Vector{Vector{Any}},
                                    network_type::Symbol=:drive,
                                    metadata::Bool=false,
-                                   download_format::Symbol=:osm
+                                   download_format::Symbol=:json
                                    )::String
 
 Forms an Overpass query string using geojosn polygon coordinates as a filter.
@@ -115,7 +115,7 @@ Forms an Overpass query string using geojosn polygon coordinates as a filter.
 - `geojson_polygons::Vector{Vector{Any}}`: Vector of `[lat, lon, ...]` polygon coordinates.
 - `network_type::Symbol=:drive`: Network type filter, pick from `:drive`, `:drive_service`, `:walk`, `:bike`, `:all`, `:all_private`, `:none`, `:rail`.
 - `metadata::Bool=false`: Set true to return metadata.
-- `download_format::Symbol=:osm`: Download format, either `:osm`, `:xml` or `json`.
+- `download_format::Symbol=:json`: Download format, either `:osm`, `:xml` or `json`.
 
 # Return
 - `String`: Overpass query string.
@@ -123,7 +123,7 @@ Forms an Overpass query string using geojosn polygon coordinates as a filter.
 function overpass_polygon_network_query(geojson_polygons::AbstractVector{<:AbstractVector},
                                         network_type::Symbol=:drive,
                                         metadata::Bool=false,
-                                        download_format::Symbol=:osm
+                                        download_format::Symbol=:json
                                         )::String
     way_filter = WAY_FILTERS_QUERY[network_type]
     relation_filter = RELATION_FILTERS_QUERY[network_type]
@@ -173,7 +173,7 @@ end
     osm_network_from_place_name(;place_name::String,
                                 network_type::Symbol=:drive,
                                 metadata::Bool=false,
-                                download_format::Symbol=:osm
+                                download_format::Symbol=:json
                                 )::String
 
 Downloads an OpenStreetMap network using any place name string.
@@ -182,7 +182,7 @@ Downloads an OpenStreetMap network using any place name string.
 - `place_name::String`: Any place name string used as a search argument to the Nominatim API.
 - `network_type::Symbol=:drive`: Network type filter, pick from `:drive`, `:drive_service`, `:walk`, `:bike`, `:all`, `:all_private`, `:none`, `:rail`.
 - `metadata::Bool=false`: Set true to return metadata.
-- `download_format::Symbol=:osm`: Download format, either `:osm`, `:xml` or `json`.
+- `download_format::Symbol=:json`: Download format, either `:osm`, `:xml` or `json`.
 
 # Return
 - `String`: OpenStreetMap network data response string.
@@ -190,7 +190,7 @@ Downloads an OpenStreetMap network using any place name string.
 function osm_network_from_place_name(;place_name::String,
                                      network_type::Symbol=:drive,
                                      metadata::Bool=false,
-                                     download_format::Symbol=:osm
+                                     download_format::Symbol=:json
                                      )::String
     geojson_polygons = polygon_from_place_name(place_name)
     query = overpass_polygon_network_query(geojson_polygons, network_type, metadata, download_format)
@@ -201,7 +201,7 @@ end
     osm_network_from_polygon(;polygon::AbstractVector,
                              network_type::Symbol=:drive,
                              metadata::Bool=false,
-                             download_format::Symbol=:osm
+                             download_format::Symbol=:json
                              )::String
 
 Downloads an OpenStreetMap network using a polygon.
@@ -210,7 +210,7 @@ Downloads an OpenStreetMap network using a polygon.
 - `polygon::AbstractVector`: Vector of longitude-latitude pairs.
 - `network_type::Symbol=:drive`: Network type filter, pick from `:drive`, `:drive_service`, `:walk`, `:bike`, `:all`, `:all_private`, `:none`, `:rail`.
 - `metadata::Bool=false`: Set true to return metadata.
-- `download_format::Symbol=:osm`: Download format, either `:osm`, `:xml` or `json`.
+- `download_format::Symbol=:json`: Download format, either `:osm`, `:xml` or `json`.
 
 # Return
 - `String`: OpenStreetMap network data response string.
@@ -218,7 +218,7 @@ Downloads an OpenStreetMap network using a polygon.
 function osm_network_from_polygon(;polygon::AbstractVector{<:AbstractVector{<:Real}},
                                   network_type::Symbol=:drive,
                                   metadata::Bool=false,
-                                  download_format::Symbol=:osm
+                                  download_format::Symbol=:json
                                   )::String
     query = overpass_polygon_network_query([polygon], network_type, metadata, download_format)
     return overpass_request(query)
@@ -228,7 +228,7 @@ end
     overpass_bbox_network_query(bbox::Vector{AbstractFloat},
                                 network_type::Symbol=:drive,
                                 metadata::Bool=false,
-                                download_format::Symbol=:osm
+                                download_format::Symbol=:json
                                 )::String
 
 Forms an Overpass query string using a bounding box as a filter.
@@ -237,7 +237,7 @@ Forms an Overpass query string using a bounding box as a filter.
 - `bbox::Vector{AbstractFloat}`: Vector of bounding box coordinates `[minlat, minlon, maxlat, maxlon]`.
 - `network_type::Symbol=:drive`: Network type filter, pick from `:drive`, `:drive_service`, `:walk`, `:bike`, `:all`, `:all_private`, `:none`, `:rail`.
 - `metadata::Bool=false`: Set true to return metadata.
-- `download_format::Symbol=:osm`: Download format, either `:osm`, `:xml` or `json`.
+- `download_format::Symbol=:json`: Download format, either `:osm`, `:xml` or `json`.
 
 # Return
 - `String`: Overpass query string.
@@ -245,7 +245,7 @@ Forms an Overpass query string using a bounding box as a filter.
 function overpass_bbox_network_query(bbox::Vector{<:AbstractFloat},
                                      network_type::Symbol=:drive,
                                      metadata::Bool=false,
-                                     download_format::Symbol=:osm
+                                     download_format::Symbol=:json
                                      )::String
     way_filter = WAY_FILTERS_QUERY[network_type]
     relation_filter = RELATION_FILTERS_QUERY[network_type]
@@ -263,7 +263,7 @@ end
                           maxlon::AbstractFloat,
                           network_type::Symbol=:drive,
                           metadata::Bool=false,
-                          download_format::Symbol=:osm
+                          download_format::Symbol=:json
                           )::String
 
 Downloads an OpenStreetMap network using bounding box coordinates.
@@ -275,7 +275,7 @@ Downloads an OpenStreetMap network using bounding box coordinates.
 - `maxlon::AbstractFloat`: Top right bounding box longitude coordinate.
 - `network_type::Symbol=:drive`: Network type filter, pick from `:drive`, `:drive_service`, `:walk`, `:bike`, `:all`, `:all_private`, `:none`, `:rail`.
 - `metadata::Bool=false`: Set true to return metadata.
-- `download_format::Symbol=:osm`: Download format, either `:osm`, `:xml` or `json`.
+- `download_format::Symbol=:json`: Download format, either `:osm`, `:xml` or `json`.
 
 # Return
 - `String`: OpenStreetMap network data response string.
@@ -286,7 +286,7 @@ function osm_network_from_bbox(;minlat::AbstractFloat,
                                maxlon::AbstractFloat,
                                network_type::Symbol=:drive,
                                metadata::Bool=false,
-                               download_format::Symbol=:osm
+                               download_format::Symbol=:json
                                )::String
     query = overpass_bbox_network_query([minlat, minlon, maxlat, maxlon], network_type, metadata, download_format)
     return overpass_request(query)
@@ -297,7 +297,7 @@ end
                            radius::Number,
                            network_type::Symbol=:drive,
                            metadata::Bool=false,
-                           download_format::Symbol=:osm
+                           download_format::Symbol=:json
                            )::String
 
 Downloads an OpenStreetMap network using bounding box coordinates calculated from a centroid point and radius (km).
@@ -307,7 +307,7 @@ Downloads an OpenStreetMap network using bounding box coordinates calculated fro
 - `radius::Number`: Distance (km) from centroid point to each bounding box corner.
 - `network_type::Symbol=:drive`: Network type filter, pick from `:drive`, `:drive_service`, `:walk`, `:bike`, `:all`, `:all_private`, `:none`, `:rail`.
 - `metadata::Bool=false`: Set true to return metadata.
-- `download_format::Symbol=:osm`: Download format, either `:osm`, `:xml` or `json`.
+- `download_format::Symbol=:json`: Download format, either `:osm`, `:xml` or `json`.
 
 # Return
 - `String`: OpenStreetMap network data response string.
@@ -316,7 +316,7 @@ function osm_network_from_point(;point::GeoLocation,
                                 radius::Number,
                                 network_type::Symbol=:drive,
                                 metadata::Bool=false,
-                                download_format::Symbol=:osm
+                                download_format::Symbol=:json
                                 )::String
     bbox = bounding_box_from_point(point, radius)
     return osm_network_from_bbox(;bbox..., network_type=network_type, metadata=metadata, download_format=download_format)
@@ -343,7 +343,7 @@ end
     download_osm_network(download_method::Symbol;
                          network_type::Symbol=:drive,
                          metadata::Bool=false,
-                         download_format::Symbol=:osm,
+                         download_format::Symbol=:json,
                          save_to_file_location::Union{String,Nothing}=nothing,
                          download_kwargs...
                          )::Union{XMLDocument,Dict{String,Any}}
@@ -354,7 +354,7 @@ Downloads an OpenStreetMap network by querying with a place name, bounding box, 
 - `download_method::Symbol`: Download method, choose from `:place_name`, `:bbox` or `:point`.
 - `network_type::Symbol=:drive`: Network type filter, pick from `:drive`, `:drive_service`, `:walk`, `:bike`, `:all`, `:all_private`, `:none`, `:rail`
 - `metadata::Bool=false`: Set true to return metadata.
-- `download_format::Symbol=:osm`: Download format, either `:osm`, `:xml` or `json`.
+- `download_format::Symbol=:json`: Download format, either `:osm`, `:xml` or `json`.
 - `save_to_file_location::Union{String,Nothing}=nothing`: Specify a file location to save downloaded data to disk.
 
 # Required Kwargs for each Download Method
@@ -391,7 +391,7 @@ Downloads an OpenStreetMap network by querying with a place name, bounding box, 
 function download_osm_network(download_method::Symbol;
                               network_type::Symbol=:drive,
                               metadata::Bool=false,
-                              download_format::Symbol=:osm,
+                              download_format::Symbol=:json,
                               save_to_file_location::Union{String,Nothing}=nothing,
                               download_kwargs...
                               )::Union{XMLDocument,Dict{String,Any}}

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -77,9 +77,9 @@ function graph_from_file(file_path::String;
                          precompute_dijkstra_states::Bool=false,
                          largest_connected_component::Bool=true
                          )::OSMGraph
-    !isfile(file_path) && throw(ErrorException("Graph file $file_path does not exist"))
-    extension = split(file_path, '.')[end]
-    deserializer = file_deserializer(Symbol(extension))
+
+    !isfile(file_path) && throw(ArgumentError("File $file_path does not exist"))
+    deserializer = file_deserializer(file_path)
     obj = deserializer(file_path)
     return graph_from_object(obj,
                              network_type=network_type,

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -93,7 +93,7 @@ end
     graph_from_download(download_method::Symbol;
                         network_type::Symbol=:drive,
                         metadata::Bool=false,
-                        download_format::Symbol=:osm,
+                        download_format::Symbol=:json,
                         save_to_file_location::Union{String,Nothing}=nothing,
                         weight_type::Symbol=:time,
                         graph_type::Symbol=:static,
@@ -108,7 +108,7 @@ Downloads OpenStreetMap network data and creates an `OSMGraph` object.
 - `download_method::Symbol`: Download method, choose from `:place_name`, `:bbox` or `:point`.
 - `network_type::Symbol=:drive`: Network type filter, pick from `:drive`, `:drive_service`, `:walk`, `:bike`, `:all`, `:all_private`, `:none`, `:rail`.
 - `metadata::Bool=false`: Set true to return metadata.
-- `download_format::Symbol=:osm`: Download format, either `:osm`, `:xml` or `json`.
+- `download_format::Symbol=:json`: Download format, either `:osm`, `:xml` or `json`.
 - `save_to_file_location::Union{String,Nothing}=nothing`: Specify a file location to save downloaded data to disk.
 - `weight_type::Symbol=:time`: Weight type for graph edges, pick from `:distance` (km), `:time` (hours), `:lane_efficiency` (time scaled by number of lanes). 
 - `graph_type::Symbol=:static`: Type of `LightGraphs.AbstractGraph`, pick from `:static` (StaticDiGraph), `:light` (DiGraph), `:simple_weighted` (SimpleWeightedDiGraph), `:meta` (MetaDiGraph).
@@ -149,7 +149,7 @@ Downloads OpenStreetMap network data and creates an `OSMGraph` object.
 function graph_from_download(download_method::Symbol;
                              network_type::Symbol=:drive,
                              metadata::Bool=false,
-                             download_format::Symbol=:osm,
+                             download_format::Symbol=:json,
                              save_to_file_location::Union{String,Nothing}=nothing,
                              weight_type::Symbol=:time,
                              graph_type::Symbol=:static,

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -20,17 +20,40 @@ function string_deserializer(format::Symbol)::Function
 end
 
 """
-    file_deserializer(format::Symbol)::Function
+    check_valid_filename(filename)
+
+Check that `filename` ends in ".json", ".osm" or ".xml",
+"""
+function check_valid_filename(filename)
+    split_name = split(filename, '.')
+    if !has_extension(filename) || !in(split_name[end], ("json", "osm", "xml"))
+        err_msg = "File $filename does not have an extension of .json, .osm or .xml"
+        throw(ArgumentError(err_msg))
+    end
+    return true
+end
+
+"""
+    get_extension(filename)
+
+Return extension of `filename`.
+"""
+get_extension(filename) = split(filename, '.')[end]
+
+"""
+    file_deserializer(file_path)::Function
 
 Retrieves file deserializer for downloaded OpenStreetMap data.
 
 # Arguments
-- `format::Symbol`: Format of OpenStreetMap darta `:xml`, `:osm` or `:json`.
+- `file_path`: File path of OSM data.
 
 # Return
 - `Function`: Either LightXML or JSON parser. 
 """
-function file_deserializer(format::Symbol)::Function
+function file_deserializer(file_path)::Function
+    check_valid_filename(file_path)
+    format = Symbol(get_extension(file_path))
     if format == :xml || format == :osm
         return LightXML.parse_file
     elseif format == :json

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -20,6 +20,13 @@ function string_deserializer(format::Symbol)::Function
 end
 
 """
+    has_extension(filename)
+
+Returns `true` if `filename` has an extension.
+"""
+has_extension(filename) = length(split(filename, '.')) > 1
+
+"""
     check_valid_filename(filename)
 
 Check that `filename` ends in ".json", ".osm" or ".xml",
@@ -61,6 +68,33 @@ function file_deserializer(file_path)::Function
     else
         throw(ArgumentError("File deserializer for $format format does not exist"))
     end
+end
+
+"""
+    validate_save_location(save_to_file_location, download_format)
+
+Check the extension of `save_to_file_location` and do the following:
+
+- If it is a valid download format but not the download format used,
+then error.
+- If the extension matches `download_format`, return `save_to_file_location`
+- If there is a different extension, append correct extension and return. This
+allows users to have periods in their file names if they wanted to
+- If no extension, add the correct extension and return
+"""
+function validate_save_location(save_to_file_location, download_format)
+    valid_formats = ("osm", "xml", "json")
+    if has_extension(save_to_file_location)
+        extension = get_extension(save_to_file_location)
+        if extension == string(download_format)
+            # File extension matches download format, all good
+            return save_to_file_location
+        elseif extension in valid_formats
+            # File extension is a different download format, error
+            throw(ArgumentError("Extension of save location $save_to_file_location does not match download format $download_format"))
+        end
+    end
+    return save_to_file_location *= "." * string(download_format)
 end
 
 """

--- a/test/download.jl
+++ b/test/download.jl
@@ -18,5 +18,8 @@ end
                                 save_to_file_location=filename);
     @test isfile(filename)
     g = graph_from_file(filename) # Check it doesn't error
-    rm(filename)
+    try
+        rm(filename)
+    catch
+    end
 end

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -79,3 +79,25 @@ end
     @test LightOSM.file_deserializer("data.json") == JSON.parsefile
     @test_throws ArgumentError LightOSM.file_deserializer("data.doc")
 end
+
+@testset "validate_save_location" begin
+    osmfilename = "folder/filename.osm"
+    @test LightOSM.validate_save_location(osmfilename, :osm) == osmfilename
+    @test_throws ArgumentError LightOSM.validate_save_location(osmfilename, :xml)
+    @test_throws ArgumentError LightOSM.validate_save_location(osmfilename, :json)
+
+    jsonfilename = "folder/filename.json"
+    @test LightOSM.validate_save_location(jsonfilename, :json) == jsonfilename
+    @test_throws ArgumentError LightOSM.validate_save_location(jsonfilename, :osm)
+    @test_throws ArgumentError LightOSM.validate_save_location(jsonfilename, :xml)
+
+    xmlfilename = "folder/filename.xml"
+    @test LightOSM.validate_save_location(xmlfilename, :xml) == xmlfilename
+    @test_throws ArgumentError LightOSM.validate_save_location(xmlfilename, :osm)
+    @test_throws ArgumentError LightOSM.validate_save_location(xmlfilename, :json)
+
+    noextension = "filename"
+    @test LightOSM.validate_save_location(noextension, :xml) == noextension * ".xml"
+    @test LightOSM.validate_save_location(noextension, :json) == noextension * ".json"
+    @test LightOSM.validate_save_location(noextension, :osm) == noextension * ".osm"
+end

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -3,10 +3,6 @@
     @test LightOSM.string_deserializer(:osm) == LightXML.parse_string
     @test LightOSM.string_deserializer(:json) == JSON.parse
     @test_throws ArgumentError LightOSM.string_deserializer(:other) 
-    @test LightOSM.file_deserializer(:xml) == LightXML.parse_file
-    @test LightOSM.file_deserializer(:osm) == LightXML.parse_file
-    @test LightOSM.file_deserializer(:json) == JSON.parsefile
-    @test_throws ArgumentError LightOSM.file_deserializer(:other)
 end
 
 @testset "string utils" begin
@@ -60,4 +56,26 @@ end
     # flatten
     @test LightOSM.flatten([1]) == [1]
     @test LightOSM.flatten([[1,2],[[3], [4]],1,2]) == [1,2,3,4,1,2]
+end
+
+@testset "file_deserializer" begin
+    # check_valid_filename
+    @test LightOSM.check_valid_filename("map.osm")
+    @test LightOSM.check_valid_filename("map.json")
+    @test LightOSM.check_valid_filename("map.xml")
+    @test_throws ArgumentError LightOSM.check_valid_filename("map.osm.doc")
+    @test_throws ArgumentError LightOSM.check_valid_filename("map.json.doc")
+    @test_throws ArgumentError LightOSM.check_valid_filename("map.xml.doc")
+    @test_throws ArgumentError LightOSM.check_valid_filename("map")
+
+    # file_deserializer
+    touch("data.osm")
+    touch("data.xml")
+    touch("data.json")
+    touch("data.doc")
+
+    @test LightOSM.file_deserializer("data.osm") == LightXML.parse_file
+    @test LightOSM.file_deserializer("data.xml") == LightXML.parse_file
+    @test LightOSM.file_deserializer("data.json") == JSON.parsefile
+    @test_throws ArgumentError LightOSM.file_deserializer("data.doc")
 end

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -69,15 +69,15 @@ end
     @test_throws ArgumentError LightOSM.check_valid_filename("map")
 
     # file_deserializer
-    touch("data.osm")
-    touch("data.xml")
-    touch("data.json")
-    touch("data.doc")
+    files = ["data.osm", "data.xml", "data.json", "data.doc"]
+    foreach(touch, files)
 
     @test LightOSM.file_deserializer("data.osm") == LightXML.parse_file
     @test LightOSM.file_deserializer("data.xml") == LightXML.parse_file
     @test LightOSM.file_deserializer("data.json") == JSON.parsefile
     @test_throws ArgumentError LightOSM.file_deserializer("data.doc")
+
+    foreach(rm, files) # tidy up
 end
 
 @testset "validate_save_location" begin


### PR DESCRIPTION
- Make `json` the default `download_format` (faster!)
- Add some checking of `save_to_file_location` (I downloaded a `map.json.osm` the other day and got confused)
- Move extension parsing for file deserialising to `file_deserializer` so it's done in one place
- Some typos in buildings docstrings
- Additional commit to remove created files in tests

The PR has these steps as separate commits so they can be stepped through individually when reviewing