### PR TITLE
Add new shortest path method to pass in weights

### DIFF
--- a/src/shortest_path.jl
+++ b/src/shortest_path.jl
@@ -139,7 +139,7 @@ Extract total edge weight along a path.
 - `sum::W`: Total path edge weight, distances are in km, time is in hours.
 """
 function total_path_weight(g::OSMGraph{U,T,W}, path::Vector{T})::W where {U <: Integer,T <: Integer,W <: Real}
-    sum::Float64 = 0.0
+    sum::W = zero(W)
     for i in 1:length(path) - 1
         sum += g.weights[g.node_to_index[path[i]], g.node_to_index[path[i + 1]]]
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,7 @@ g_distance = graph_from_object(data, weight_type=:distance) # replace by better 
     @testset "Geometry" begin include("geometry.jl") end
     @testset "Download" begin include("download.jl") end
     @testset "Nearest Node" begin include("nearest_node.jl") end
+    @testset "Shortest Path" begin include("shortest_path.jl") end
 end
 
 # Tidy up

--- a/test/shortest_path.jl
+++ b/test/shortest_path.jl
@@ -1,0 +1,33 @@
+# Basic use
+edge = iterate(keys(g_distance.edge_to_highway))[1]
+node1_id = edge[1]
+node2_id = edge[2]
+path = shortest_path(g_distance, node1_id, node2_id)
+@test path[1] == node1_id
+@test path[2] == node2_id
+
+# Test using nodes rather than node IDs get same results
+path_from_nodes = shortest_path(g_distance, g_distance.nodes[node1_id], g_distance.nodes[node2_id])
+@test path_from_nodes == path
+
+# Pass in weights directly
+path_with_weights = shortest_path(g_distance, g_distance.nodes[node1_id], g_distance.nodes[node2_id], g_distance.weights)
+@test path_with_weights == path
+
+# Also test astar doesn't error
+path_astar = shortest_path(g_distance, node1_id, node2_id, algorithm=:astar)
+@test path_astar==path
+
+# Test edge weight sum equals the weight in g_distance.weights
+@test total_path_weight(g_distance, path) == g_distance.weights[g_distance.node_to_index[node1_id],g_distance.node_to_index[node2_id]]
+@test total_path_weight(g_distance, path) == sum(weights_from_path(g_distance, path))
+
+# Test time weights
+path_time_weights = shortest_path(g_time, node1_id, node2_id)
+path_time_weights_astar = shortest_path(g_time, node1_id, node2_id, algorithm=:astar)
+@test path_time_weights[1] == node1_id
+@test path_time_weights[2] == node2_id
+@test path_time_weights == path_time_weights_astar
+
+edge_speed = g_distance.highways[g_distance.edge_to_highway[edge]].tags["maxspeed"]
+@test isapprox(total_path_weight(g_distance, path) / total_path_weight(g_time, path), edge_speed)

--- a/test/shortest_path.jl
+++ b/test/shortest_path.jl
@@ -11,7 +11,7 @@ path_from_nodes = shortest_path(g_distance, g_distance.nodes[node1_id], g_distan
 @test path_from_nodes == path
 
 # Pass in weights directly
-path_with_weights = shortest_path(g_distance, g_distance.nodes[node1_id], g_distance.nodes[node2_id], g_distance.weights)
+path_with_weights = shortest_path(g_distance, g_distance.nodes[node1_id], g_distance.nodes[node2_id]; weights=g_distance.weights)
 @test path_with_weights == path
 
 # Also test astar doesn't error


### PR DESCRIPTION
Tidied up methods so that kwargs are only defined once, and added new method that passes in weights. Added `shortest_path` tests.

Also tidied up typing in `total_path_weight` (separate commit for review clarity)