### PR TITLE
Stop `add_indexed_restrictions!` from reversing order of nodes in way object

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LightOSM"
 uuid = "d1922b25-af4e-4ba3-84af-fe9bea896051"
 authors = ["Jack Chan <jchan2@deloitte.com.au>"]
-version = "0.1.16"
+version = "0.1.17"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -306,8 +306,9 @@ function add_indexed_restrictions!(g::OSMGraph{U,T,W}) where {U <: Integer,T <: 
             to_node = adjacent_node(g, to_via_intersection_node, r.to_way)::T
 
             if to_via_intersection_node == via_way_nodes[end]
-                # Ordering matters, see doc string
-                reverse!(via_way_nodes)
+                # Ordering matters, see doc string, but 
+                # we don't want to reorder the array in the Way object
+                via_way_nodes = reverse(via_way_nodes)
             end
 
             indices = [g.node_to_index[n] for n in [to_node, via_way_nodes..., from_node]]


### PR DESCRIPTION
The `reverse!` was reversing the nodes in the `Way` object unintentionally