### PR TITLE
Rename highways to ways

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LightOSM"
 uuid = "d1922b25-af4e-4ba3-84af-fe9bea896051"
 authors = ["Jack Chan <jchan2@deloitte.com.au>"]
-version = "0.1.19"
+version = "0.1.20"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/docs/src/testing_use.md
+++ b/docs/src/testing_use.md
@@ -66,7 +66,7 @@ Creating the graph relies on some LightOSM internals to populate all other field
 U = LightOSM.DEFAULT_OSM_INDEX_TYPE
 T = LightOSM.DEFAULT_OSM_ID_TYPE
 W = LightOSM.DEFAULT_OSM_EDGE_WEIGHT_TYPE
-g = OSMGraph{U,T,W}(nodes=nodes, highways=ways)
+g = OSMGraph{U,T,W}(nodes=nodes, ways=ways)
 LightOSM.add_node_and_edge_mappings!(g)
 LightOSM.add_weights!(g, :distance) # or :time
 LightOSM.add_graph!(g, :static) # or any desired graph type
@@ -99,7 +99,7 @@ See [`Restriction`](@ref) for more information on `Restriction` objects.
 And then when instantiating the `OSMGraph`
 
 ```julia
-g = OSMGraph{U,T,W}(nodes=nodes, highways=ways, restrictions=restrictions)
+g = OSMGraph{U,T,W}(nodes=nodes, ways=ways, restrictions=restrictions)
 LightOSM.add_indexed_restrictions!(g)
 ```
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -86,11 +86,11 @@ Container for storing OpenStreetMap node, way, relation and graph related obejct
 `U <: Integer,T <: Integer,W <: Real`
 - `nodes::Dict{T,Node{T}}`: Mapping of node ids to node objects.
 - `node_coordinates::Vector{Vector{W}}`: Vector of node coordinates [[lat, lon]...], indexed by graph vertices.
-- `highways::Dict{T,Way{T}}`: Mapping of way ids to way objects.
+- `ways::Dict{T,Way{T}}`: Mapping of way ids to way objects. Previously called `highways`.
 - `node_to_index::OrderedDict{T,U}`: Mapping of node ids to graph vertices.
 - `index_to_node::OrderedDict{U,T}`: Mapping of graph vertices to node ids.
-- `node_to_highway::Dict{T,Vector{T}}`: Mapping of node ids to vector of way ids.
-- `edge_to_highway::Dict{Vector{T},T}`: Mapping of edges (adjacent node pairs) to way ids.
+- `node_to_way::Dict{T,Vector{T}}`: Mapping of node ids to vector of way ids. Previously called `node_to_highway`.
+- `edge_to_way::Dict{Vector{T},T}`: Mapping of edges (adjacent node pairs) to way ids. Previously called `edge_to_highway`.
 - `restrictions::Dict{T,Restriction{T}}`: Mapping of relation ids to restriction objects.
 - `indexed_restrictions::Union{DefaultDict{U,Vector{MutableLinkedList{U}}},Nothing}`: Mapping of via node ids to ordered sequences of restricted node ids.
 - `graph::Union{AbstractGraph,Nothing}`: Either DiGraph, StaticDiGraph, SimpleWeightedDiGraph or MetaDiGraph.
@@ -102,11 +102,11 @@ Container for storing OpenStreetMap node, way, relation and graph related obejct
 @with_kw mutable struct OSMGraph{U <: Integer,T <: Integer,W <: Real}
     nodes::Dict{T,Node{T}} = Dict{T,Node{T}}()
     node_coordinates::Vector{Vector{W}} = Vector{Vector{W}}() # needed for astar heuristic
-    highways::Dict{T,Way{T}} = Dict{T,Way{T}}()
+    ways::Dict{T,Way{T}} = Dict{T,Way{T}}()
     node_to_index::OrderedDict{T,U} = OrderedDict{T,U}()
     index_to_node::OrderedDict{U,T} = OrderedDict{U,T}()
-    node_to_highway::Dict{T,Vector{T}} = Dict{T,Vector{T}}()
-    edge_to_highway::Dict{Vector{T},T} = Dict{Vector{T},T}()
+    node_to_way::Dict{T,Vector{T}} = Dict{T,Vector{T}}()
+    edge_to_way::Dict{Vector{T},T} = Dict{Vector{T},T}()
     restrictions::Dict{T,Restriction{T}} = Dict{T,Restriction{T}}()
     indexed_restrictions::Union{DefaultDict{U,Vector{MutableLinkedList{U}}},Nothing} = nothing
     graph::Union{AbstractGraph,Nothing} = nothing
@@ -114,6 +114,19 @@ Container for storing OpenStreetMap node, way, relation and graph related obejct
     dijkstra_states::Union{Vector{Vector{U}},Nothing} = nothing
     kdtree::Union{KDTree,Nothing} = nothing
     weight_type::Union{Symbol,Nothing} = nothing
+end
+
+function Base.getproperty(g::OSMGraph, field::Symbol)
+    # Ensure renaming of "highways" to "ways" is backwards compatible
+    if field === :highways
+        return getfield(g, :ways)
+    elseif field === :node_to_highway
+        return getfield(g, :node_to_way)
+    elseif field === :edge_to_highway
+        return getfield(g, :edge_to_way)
+    else
+        return getfield(g, field)
+    end
 end
 
 """

--- a/test/graph.jl
+++ b/test/graph.jl
@@ -1,0 +1,7 @@
+g = basic_osm_graph_stub()
+
+@testset "Backwards compatibility" begin
+    @test g.ways === g.highways
+    @test g.node_to_way === g.node_to_highway
+    @test g.edge_to_way === g.edge_to_highway
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,4 +13,5 @@ include("stub.jl")
     @testset "Download" begin include("download.jl") end
     @testset "Nearest Node" begin include("nearest_node.jl") end
     @testset "Shortest Path" begin include("shortest_path.jl") end
+    @testset "Graph" begin include("graph.jl") end
 end

--- a/test/shortest_path.jl
+++ b/test/shortest_path.jl
@@ -2,7 +2,7 @@ g_distance = basic_osm_graph_stub()
 g_time = basic_osm_graph_stub(:time)
 
 # Basic use
-edge = iterate(keys(g_distance.edge_to_highway))[1]
+edge = iterate(keys(g_distance.edge_to_way))[1]
 node1_id = edge[1]
 node2_id = edge[2]
 path = shortest_path(g_distance, node1_id, node2_id)
@@ -36,7 +36,7 @@ path_time_weights_astar = shortest_path(g_time, node1_id, node2_id, algorithm=:a
 @test path_time_weights[2] == node2_id
 @test path_time_weights == path_time_weights_astar
 
-edge_speed = g_distance.highways[g_distance.edge_to_highway[edge]].tags["maxspeed"]
+edge_speed = g_distance.ways[g_distance.edge_to_way[edge]].tags["maxspeed"]
 @test isapprox(total_path_weight(g_distance, path) / total_path_weight(g_time, path), edge_speed)
 
 # Test paths we know the result of from the stub graph

--- a/test/stub.jl
+++ b/test/stub.jl
@@ -62,7 +62,7 @@ function basic_osm_graph_stub(weight_type=:distance, graph_type=:static)
     U = LightOSM.DEFAULT_OSM_INDEX_TYPE
     T = LightOSM.DEFAULT_OSM_ID_TYPE
     W = LightOSM.DEFAULT_OSM_EDGE_WEIGHT_TYPE
-    g = OSMGraph{U,T,W}(nodes=nodes, highways=ways, restrictions=restrictions)
+    g = OSMGraph{U,T,W}(nodes=nodes, ways=ways, restrictions=restrictions)
     LightOSM.add_node_and_edge_mappings!(g)
     LightOSM.add_weights!(g, weight_type)
     LightOSM.add_graph!(g, graph_type)


### PR DESCRIPTION
Rename `highways`, `node_to_highway` and `edge_to_highway` fields of `OSMGraph` struct to `ways`, `node_to_way` and `edge_to_way` respectively.  Overload `getproperty` so that this change is backwards compatible.

Am I right in thinking that we don't consider the constructors for OSMGraph part of the public API? I put as much in [the documentation](https://deloittedigitalapac.github.io/LightOSM.jl/docs/testing_use/#Graph-creation). If that's the case then this is not a breaking change, if it's not then technically we are changing the keyword arguments of the constructor.

What do you think @captchanjack ?

Closes #18