### PR TITLE
WIP: Simplify Graph

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,8 @@ authors = ["Jack Chan <jchan2@deloitte.com.au>"]
 version = "0.1.19"
 
 [deps]
+ArchGDAL = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"

--- a/src/LightOSM.jl
+++ b/src/LightOSM.jl
@@ -4,14 +4,16 @@ using Parameters
 using DataStructures: DefaultDict, OrderedDict, MutableLinkedList, PriorityQueue, dequeue!, dequeue_pair!
 using Statistics: mean
 using SparseArrays: SparseMatrixCSC, sparse
-using Graphs: AbstractGraph, DiGraph, nv, outneighbors, weakly_connected_components, vertices
+using Graphs: AbstractGraph, DiGraph, nv, outneighbors, weakly_connected_components, vertices, all_neighbors, indegree, outdegree, add_edge!
 using StaticGraphs: StaticDiGraph
 using SimpleWeightedGraphs: SimpleWeightedDiGraph
 using MetaGraphs: MetaDiGraph
 using NearestNeighbors: KDTree, knn
+using ArchGDAL: IGeometry, createlinestring, createpoint
 using HTTP
 using JSON
 using LightXML
+using DataFrames
 
 export GeoLocation,
        OSMGraph,
@@ -33,7 +35,8 @@ export GeoLocation,
        download_osm_buildings,
        buildings_from_object,
        buildings_from_download,
-       buildings_from_file
+       buildings_from_file,
+       simplify_graph
 
 include("types.jl")
 include("constants.jl")
@@ -46,5 +49,6 @@ include("traversal.jl")
 include("shortest_path.jl")
 include("nearest_node.jl")
 include("buildings.jl")
+include("simplification.jl")
 
 end # module

--- a/src/simplification.jl
+++ b/src/simplification.jl
@@ -1,0 +1,96 @@
+
+#adapted from osmnx: https://github.com/gboeing/osmnx/blob/main/osmnx/simplification.py
+
+"""
+Predicate wether v is an edge endpoint in the simplified version of g
+"""
+function is_endpoint(g::AbstractGraph, v)
+    neighbors = all_neighbors(g, v)
+    if v in neighbors # has self loop
+        return true
+    elseif outdegree(g, v) == 0 || indegree(g, v) == 0 # sink or source
+        return true
+    elseif length(neighbors) != 2 || indegree(g, v) != outdegree(g, v) # change to one way
+        return true
+    end
+    return false
+end
+
+"""
+iterator over all endpoints in g
+"""
+endpoints(g::AbstractGraph) = (v for v in vertices(g) if is_endpoint(g, v))
+
+"""
+iterator over all paths in g which can be contracted
+"""
+function paths_to_reduce(g::AbstractGraph)
+    (path_to_endpoint(g, (u, v)) for u in endpoints(g) for v in outneighbors(g, u))
+end
+
+"""
+path to the next endpoint starting in edge (ep, ep_succ)
+"""
+function path_to_endpoint(g::AbstractGraph, (ep, ep_succ)::Tuple{T,T}) where {T<:Integer}
+    path = [ep, ep_succ]
+    head = ep_succ
+    # ep_succ not in endpoints -> has 2 neighbors and degree 2 or 4
+    while !is_endpoint(g, head)
+        neighbors = [n for n in outneighbors(g, head) if n != path[end-1]]
+        @assert length(neighbors) == 1 "found unmarked endpoint!"
+        head, = neighbors
+        push!(path, head)
+        (head == ep) && return path # self loop
+    end
+    return path
+end
+
+"""
+Build a new graph which simplifies the topology of osmg.graph.
+The resulting graph only contains intersections and dead ends from the original graph.
+The geometry of the contracted nodes is kept in the edge_gdf DataFrame
+"""
+function simplify_graph(osmg::OSMGraph)
+    g = osmg.graph
+    relevant_nodes = collect(endpoints(g))
+    n = length(relevant_nodes)
+    (n == nv(g)) && return g # nothing to simplify here
+
+
+    G_simplified = DiGraph(n) 
+    weights = similar(osmg.weights, (n, n))
+    edge_gdf = DataFrame(
+        u = Int[],
+        v = Int[],
+        key = Int[],
+        weight = Vector{eltype(osmg.weights)}(),
+        geom = IGeometry[],
+    )
+    node_gdf = DataFrame(id = Int[], geom = IGeometry[])
+
+
+    index_mapping = Dict{Int,Int}()
+    for (new_i, old_i) in enumerate(relevant_nodes)
+        index_mapping[old_i] = new_i
+        geo = createpoint(osmg.node_coordinates[old_i])
+        push!(node_gdf, (new_i, geo))
+    end
+
+    for path in paths_to_reduce(g)
+        u = index_mapping[first(path)]
+        v = index_mapping[last(path)]
+        edge_weight = sum((osmg.weights[i, i+1] for i in 1:length(path)-1))
+        geo = createlinestring(osmg.node_coordinates[path])
+
+        if add_edge!(G_simplified, (u, v))
+            key = 0
+            weights[u, v] = edge_weight
+        else # parallel edge
+            key = sum((edge_gdf.u .== u) .& (edge_gdf.v .== v))
+            weights[u, v] = min(edge_weight, weights[u, v])
+        end
+        push!(edge_gdf, (u, v, key, edge_weight, geo))
+    end
+
+    return G_simplified, weights, node_gdf, edge_gdf
+end


### PR DESCRIPTION
This PR implements an algorithm for simplifying the topology of an `OSMGraph` object.
It is adapted from [osmnx](https://github.com/gboeing/osmnx/blob/main/osmnx/simplification.py).

This PR is work in progress, and a few issues have to be discussed.

TODO:
1.  the output format of the simplification procedure (rn it returns a `DiGraph` and two `DataFrames`: one for nodes and the other for edges (which also contains the edge geometry) )
2. reference to the original OSM objects (an edge can consist of serveral ways)
3. turn restrictions
4. type stability and code generalization for types

Below is an example for Tiergarten district in Mitte, Berlin, Germany:


Before the simplification:
nodes: 2976,
egdes: 4727
![before](https://user-images.githubusercontent.com/25564498/147956502-d848f948-301f-4f53-b390-07a838fa497a.png)


After the simplification:
nodes: 683, 
edges: 1384
![after](https://user-images.githubusercontent.com/25564498/147956515-5bed48c7-3c5d-4a49-90fc-c12d997dd8fa.png)

I will upload an example script the following days.
