### PR TITLE
More concise REPL output for GeoLocation

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -5,7 +5,7 @@ Representation of a geospatial coordinates.
 - `lon::Float64`: Longitude.
 - `alt::Float64`: Altitude.
 """
-@with_kw struct GeoLocation
+@with_kw_noshow struct GeoLocation
     lat::Float64
     lon::Float64
     alt::Float64 = 0.0


### PR DESCRIPTION
The `@with_kw` macro has a very verbose output in the REPL by default:
```julia
julia> GeoLocation(-37.81841234315089, 144.95655834674835)
GeoLocation
  lat: Float64 -37.81841234315089
  lon: Float64 144.95655834674835
  alt: Float64 0.0
```

This is a problem when it is part of a struct e.g. `Node`:
```julia
julia> g.nodes[3306900957]
Node{Int64}(3306900957, GeoLocation
  lat: Float64 -37.8191237
  lon: Float64 144.9599131
  alt: Float64 0.0
, Dict{String, Any}("lanes" => 1, "maxspeed" => 45))
```

Solution is to define `GeoLocation` using the `@with_kw_noshow` macro instead of `@with_kw`. This gives an output more consistent with the rest of Julia:
```julia
julia> g.nodes[3306900957]
Node{Int64}(3306900957, GeoLocation(-37.8191237, 144.9599131, 0.0), Dict{String, Any}("lanes" => 1, "maxspeed" => 45))
```
