### PR TITLE
Add methods to create a sub-OSMGraph from an OSMGraph

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LightOSM"
 uuid = "d1922b25-af4e-4ba3-84af-fe9bea896051"
 authors = ["Jack Chan <jchan2@deloitte.com.au>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/docs/src/create_graph.md
+++ b/docs/src/create_graph.md
@@ -4,4 +4,5 @@
 graph_from_object
 graph_from_download
 graph_from_file
+osm_subgraph
 ```

--- a/src/LightOSM.jl
+++ b/src/LightOSM.jl
@@ -45,7 +45,9 @@ export GeoLocation,
        download_osm_buildings,
        buildings_from_object,
        buildings_from_download,
-       buildings_from_file
+       buildings_from_file,
+       osm_subgraph,
+       get_graph_type
 
 export index_to_node_id,
        index_to_node,
@@ -70,5 +72,6 @@ include("traversal.jl")
 include("shortest_path.jl")
 include("nearest_node.jl")
 include("buildings.jl")
+include("subgraph.jl")
 
 end # module

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -452,3 +452,25 @@ function add_kdtree!(g::OSMGraph)
     cartesian_locations = to_cartesian(node_locations)
     g.kdtree = KDTree(cartesian_locations)
 end
+
+"""
+    get_graph_type(g::OSMGraph)
+
+Detects the type of the underlying graph object `g.graph` and returns the Symbol
+used to specify that type in `add_graph!`.
+"""
+function get_graph_type(g::OSMGraph)
+    graph_type = typeof(g.graph)
+
+    if graph_type <: DiGraph
+        return :light
+    elseif graph_type <: StaticDiGraph
+        return :static
+    elseif graph_type <: SimpleWeightedDiGraph
+        return :simple_weighted
+    elseif graph_type <: MetaDiGraph
+        return :meta
+    else
+        throw(ErrorException("Graph is of unexpected type $graph_type"))
+    end
+end

--- a/src/subgraph.jl
+++ b/src/subgraph.jl
@@ -1,0 +1,56 @@
+"""
+    osm_subgraph(g::OSMGraph{U, T, W},
+                 vertex_list::Vector{U}
+                 )::OSMGraph where {U <: Integer, T <: Integer, W <: Real}
+
+Create an OSMGraph representing a subgraph of another OSMGraph containing 
+specified vertices.
+The resulting OSMGraph object will also contain vertices from all ways that the
+specified vertices (nodes) are members of.
+Vertex numbers within the graph object are not mapped onto the subgraph.
+"""
+function osm_subgraph(g::OSMGraph{U, T, W},
+                      vertex_list::Vector{U}
+                      ) where {U, T, W}
+
+    # Get all nodes and ways for the subgraph
+    nodelist = [g.nodes[g.index_to_node[v]] for v in vertex_list]
+    waylist = [g.ways[w] for w in collect(Iterators.flatten([g.node_to_way[n.id] for n in nodelist]))]
+    way_ids = [w.id for w in waylist]
+    ways = Dict{T, Way{T}}(way_ids .=> waylist)
+
+    # Make sure number of nodes matches number of nodes from ways (adds some nodes to graph)
+    for way in values(ways)
+        append!(nodelist, [g.nodes[n] for n in setdiff(g.ways[way.id].nodes, nodelist)])
+    end
+    nodes = Dict{T, Node{T}}([n.id for n in nodelist] .=> nodelist)
+
+    # Get restrictions that involve selected ways
+    restrictions = Dict{T, Restriction{T}}()
+    for res in values(g.restrictions)
+        if in(res.from_way, way_ids) || in(res.to_way, way_ids)
+            restrictions[res.id] = res
+        end
+    end
+
+    # Construct the OSMGraph
+    osg = OSMGraph{U, T, W}(nodes=nodes, ways=ways, restrictions=restrictions)
+    LightOSM.add_node_and_edge_mappings!(osg)
+    !isnothing(g.weight_type) && add_weights!(osg, g.weight_type)
+    LightOSM.add_graph!(osg, get_graph_type(g))
+    LightOSM.add_node_tags!(osg)
+
+    if isdefined(g.dijkstra_states, 1)
+        add_dijkstra_states!(osg)
+    else
+        osg.dijkstra_states = Vector{Vector{U}}(undef, length(osg.nodes))
+    end
+
+    !isnothing(g.kdtree) && add_kdtree!(osg)
+
+    return osg
+end
+
+function osm_subgraph(g::OSMGraph{U, T, W}, node_list::Vector{T}) where {U <: Integer, T <: Integer, W <: Real} 
+    return osm_subgraph(g, [g.node_to_index[n] for n in node_list])
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,4 +17,5 @@ include("stub.jl")
     @testset "Shortest Path" begin include("shortest_path.jl") end
     @testset "Graph" begin include("graph.jl") end
     @testset "Traversal" begin include("traversal.jl") end
+    @testset "Subgraph" begin include("subgraph.jl") end
 end

--- a/test/subgraph.jl
+++ b/test/subgraph.jl
@@ -1,0 +1,20 @@
+g = basic_osm_graph_stub()
+
+@testset "Subgraph" begin
+    # Create a subgraph using all nodes/vertices from g for testing
+    nlist = [n.id for n in values(g.nodes)]
+    sg = osm_subgraph(g, nlist)
+    @test get_graph_type(g) === :static
+    @test sg.nodes == g.nodes
+    @test sg.ways == g.ways
+    @test sg.restrictions == g.restrictions
+    @test sg.weight_type == g.weight_type
+    @test isdefined(sg.dijkstra_states, 1) == isdefined(g.dijkstra_states, 1)
+    if isdefined(g.dijkstra_states, 1)
+        @test sg.dijkstra_states == g.dijkstra_states
+    end
+    @test isdefined(sg.kdtree, 1) == isdefined(g.kdtree, 1)
+    if isdefined(g.kdtree, 1)
+        @test typeof(sg.kdtree) == typeof(g.kdtree)
+    end
+end


### PR DESCRIPTION
 Create an OSMGraph that is a subgraph of the original with the relevant metadata. Requires an OSMGraph and a list of vertices or node IDs.