### PR TITLE
Fixes for subgraph/GeoLocation/MetaGraph typing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LightOSM"
 uuid = "d1922b25-af4e-4ba3-84af-fe9bea896051"
 authors = ["Jack Chan <jchan2@deloitte.com.au>"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/LightOSM.jl
+++ b/src/LightOSM.jl
@@ -4,11 +4,11 @@ using Parameters
 using DataStructures: DefaultDict, OrderedDict, MutableLinkedList
 using QuickHeaps: BinaryHeap, FastMin
 using Statistics: mean
-using SparseArrays: SparseMatrixCSC, sparse
+using SparseArrays: SparseMatrixCSC, sparse, findnz
 using Graphs: AbstractGraph, DiGraph, nv, outneighbors, weakly_connected_components, vertices
 using StaticGraphs: StaticDiGraph
 using SimpleWeightedGraphs: SimpleWeightedDiGraph
-using MetaGraphs: MetaDiGraph
+using MetaGraphs: MetaDiGraph, set_prop!
 using NearestNeighbors: Euclidean, KDTree, knn, nn
 using HTTP
 using JSON

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -374,16 +374,16 @@ end
 
 Adds a Graphs.AbstractGraph object to `OSMGraph`.
 """
-function add_graph!(g::OSMGraph, graph_type::Symbol=:static)
+function add_graph!(g::OSMGraph{U, T, W}, graph_type::Symbol=:static) where {U <: Integer, T <: Integer, W <: Real}
     if graph_type == :light
-        g.graph = DiGraph(g.weights)
+        g.graph = DiGraph{T}(g.weights)
     elseif graph_type == :static
-        g.graph = StaticDiGraph(DiGraph(g.weights))
+        g.graph = StaticDiGraph{U,U}(StaticDiGraph(DiGraph(g.weights)))
     elseif graph_type == :simple_weighted
-        g.graph = SimpleWeightedDiGraph(g.weights)
+        g.graph = SimpleWeightedDiGraph{U,W}(g.weights)
     elseif graph_type == :meta
-        g.graph = MetaDiGraph(DiGraph(g.weights))
-        for (o, d, w) in zip(findnz(transpose(g.weights))...)
+        g.graph = MetaDiGraph(DiGraph{T}(g.weights))
+        for (o, d, w) in zip(findnz(copy(transpose(g.weights)))...)
             set_prop!(g.graph, o, d, :weight, w)
         end
     else

--- a/src/types.jl
+++ b/src/types.jl
@@ -12,8 +12,10 @@ Representation of a geospatial coordinates.
 end
 
 GeoLocation(lat::AbstractFloat, lon::AbstractFloat)::GeoLocation = GeoLocation(lat=lat, lon=lon)
+GeoLocation(lat::Real, lon::Real)::GeoLocation = GeoLocation(lat=float(lat), lon=float(lon))
 GeoLocation(point::Vector{<:AbstractFloat})::GeoLocation = GeoLocation(point...)
-GeoLocation(point_vector::Vector{<:Vector{<:AbstractFloat}})::Vector{GeoLocation} = [GeoLocation(p...) for p in point_vector]
+GeoLocation(point::Vector{<:Real})::GeoLocation = GeoLocation([float(coord) for coord in point]...)
+GeoLocation(point_vector::Vector{<:Vector{<:Real}})::Vector{GeoLocation} = [GeoLocation(p...) for p in point_vector]
 
 function Base.:(==)(loc1::GeoLocation, loc2::GeoLocation)
     return loc1.lat == loc2.lat && loc1.lon == loc2.lon && loc1.alt == loc2.alt

--- a/test/subgraph.jl
+++ b/test/subgraph.jl
@@ -5,6 +5,7 @@ g = basic_osm_graph_stub()
     nlist = [n.id for n in values(g.nodes)]
     sg = osm_subgraph(g, nlist)
     @test get_graph_type(g) === :static
+    @test typeof(sg.graph) === typeof(g.graph)
     @test sg.nodes == g.nodes
     @test sg.ways == g.ways
     @test sg.restrictions == g.restrictions
@@ -17,4 +18,19 @@ g = basic_osm_graph_stub()
     if isdefined(g.kdtree, 1)
         @test typeof(sg.kdtree) == typeof(g.kdtree)
     end
+
+    g.graph = nothing
+    LightOSM.add_graph!(g, :light)
+    sg = osm_subgraph(g, nlist)
+    @test typeof(sg.graph) === typeof(g.graph)
+
+    g.graph = nothing
+    LightOSM.add_graph!(g, :simple_weighted)
+    sg = osm_subgraph(g, nlist)
+    @test typeof(sg.graph) === typeof(g.graph)
+
+    g.graph = nothing
+    LightOSM.add_graph!(g, :meta)
+    sg = osm_subgraph(g, nlist)
+    @test typeof(sg.graph) === typeof(g.graph)
 end

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -1,4 +1,4 @@
-@testset "desiralizers" begin
+@testset "deserializers" begin
     @test LightOSM.string_deserializer(:xml) == LightXML.parse_string
     @test LightOSM.string_deserializer(:osm) == LightXML.parse_string
     @test LightOSM.string_deserializer(:json) == JSON.parse
@@ -100,4 +100,21 @@ end
     @test LightOSM.validate_save_location(noextension, :xml) == noextension * ".xml"
     @test LightOSM.validate_save_location(noextension, :json) == noextension * ".json"
     @test LightOSM.validate_save_location(noextension, :osm) == noextension * ".osm"
+end
+
+@testset "type consistency" begin
+    floats = Vector{Vector{Float64}}([
+        Vector{Float64}([23.0, 123.0]),
+        Vector{Float64}([-23.0, 122.0]),
+        Vector{Float64}([-30.0, 121.0])
+        ])
+    ints = Vector{Vector{Int64}}([
+        Vector{Int64}([23, 123]),
+        Vector{Int64}([-23, 122]),
+        Vector{Int64}([-30, 121])
+        ])
+    @test GeoLocation(floats[1][1], floats[1][2]) === GeoLocation(ints[1][1], ints[1][2])
+    @test GeoLocation(floats[1]) === GeoLocation(ints[1])
+    @test GeoLocation(floats) == GeoLocation(ints)
+    @test typeof(GeoLocation(floats)) === typeof(GeoLocation(ints))
 end


### PR DESCRIPTION
- Graph object typing in `add_graph!` now depends on the OSMGraph types. This ensures subgraphs are generated with graph objects that match the typing of the parent OSMGraph.graph
- GeoLocation constructor methods added to capture `Real` inputs and convert to float. This allows GeoLocations to still be correctly produced when Dict parsing of coordinates incorrectly uses an integer type.
- Other minor fixes found during testing of the above: methods used to generate a MetaGraph in `add_graph!` were not imported; and the transpose of the SparseMatrix of weights needed to be instantiated (done via `copy`) for passing into `findnz` during MetaGraph construction.