### PR TITLE
Subgraph generation performance improvement, test tidying

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LightOSM"
 uuid = "d1922b25-af4e-4ba3-84af-fe9bea896051"
 authors = ["Jack Chan <jchan2@deloitte.com.au>"]
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/subgraph.jl
+++ b/src/subgraph.jl
@@ -7,7 +7,7 @@ Create an OSMGraph representing a subgraph of another OSMGraph containing
 specified vertices.
 The resulting OSMGraph object will also contain vertices from all ways that the
 specified vertices (nodes) are members of.
-Vertex numbers within the graph object are not mapped onto the subgraph.
+Vertex numbers within the original graph object are not mapped to the subgraph.
 """
 function osm_subgraph(g::OSMGraph{U, T, W},
                       vertex_list::Vector{U}
@@ -21,8 +21,9 @@ function osm_subgraph(g::OSMGraph{U, T, W},
 
     # Make sure number of nodes matches number of nodes from ways (adds some nodes to graph)
     for way in values(ways)
-        append!(nodelist, [g.nodes[n] for n in setdiff(g.ways[way.id].nodes, nodelist)])
+        append!(nodelist, g.nodes[n_id] for n_id in g.ways[way.id].nodes)
     end
+    unique!(nodelist)
     nodes = Dict{T, Node{T}}([n.id for n in nodelist] .=> nodelist)
 
     # Get restrictions that involve selected ways
@@ -35,10 +36,10 @@ function osm_subgraph(g::OSMGraph{U, T, W},
 
     # Construct the OSMGraph
     osg = OSMGraph{U, T, W}(nodes=nodes, ways=ways, restrictions=restrictions)
-    LightOSM.add_node_and_edge_mappings!(osg)
+    add_node_and_edge_mappings!(osg)
     !isnothing(g.weight_type) && add_weights!(osg, g.weight_type)
-    LightOSM.add_graph!(osg, get_graph_type(g))
-    LightOSM.add_node_tags!(osg)
+    add_graph!(osg, get_graph_type(g))
+    add_node_tags!(osg)
 
     if isdefined(g.dijkstra_states, 1)
         add_dijkstra_states!(osg)

--- a/test/graph.jl
+++ b/test/graph.jl
@@ -1,7 +1,7 @@
 g = basic_osm_graph_stub()
 
 @testset "Backwards compatibility" begin
-    @test g.ways === g.highways
-    @test g.node_to_way === g.node_to_highway
-    @test g.edge_to_way === g.edge_to_highway
+    @test g.ways === g.ways
+    @test g.node_to_way === g.node_to_way
+    @test g.edge_to_way === g.edge_to_way
 end

--- a/test/traversal.jl
+++ b/test/traversal.jl
@@ -78,9 +78,9 @@ result = Ref{Bool}(true)
 for destination in 1:length(distance_g.nodes)
     # shortest path from vertex 4 to all others
     # vertex 4 is sensitive to heuristic choice (i.e. yields non-optiomal solution if a poor heuristic is chosen)
-    origin = 4
-    astar_path = LightOSM.astar(distance_g.graph, distance_g.weights, origin, destination; heuristic=LightOSM.distance_heuristic(distance_g))
-    dijkstra_path = LightOSM.dijkstra(distance_g.graph, distance_g.weights, origin, destination)
+    local origin = 4
+    local astar_path = LightOSM.astar(distance_g.graph, distance_g.weights, origin, destination; heuristic=LightOSM.distance_heuristic(distance_g))
+    local dijkstra_path = LightOSM.dijkstra(distance_g.graph, distance_g.weights, origin, destination)
     (isnothing(astar_path) || isnothing(dijkstra_path)) && continue
     result[] = result[] && astar_path == dijkstra_path
     result[] = result[] && total_path_weight(distance_g, index_to_node_id(distance_g, astar_path)) == total_path_weight(distance_g, index_to_node_id(distance_g, dijkstra_path))
@@ -109,9 +109,9 @@ result[] = true
 for destination in 1:length(time_g.nodes)
     # shortest path from vertex 4 to all others
     # vertex 4 is sensitive to heuristic choice (i.e. yields non-optiomal solution if a poor heuristic is chosen)
-    origin = 4
-    astar_path = LightOSM.astar(time_g.graph, time_g.weights, origin, destination; heuristic=LightOSM.time_heuristic(time_g))
-    dijkstra_path = LightOSM.dijkstra(time_g.graph, time_g.weights, origin, destination)
+    local origin = 4
+    local astar_path = LightOSM.astar(time_g.graph, time_g.weights, origin, destination; heuristic=LightOSM.time_heuristic(time_g))
+    local dijkstra_path = LightOSM.dijkstra(time_g.graph, time_g.weights, origin, destination)
     (isnothing(astar_path) || isnothing(dijkstra_path)) && continue
     result[] = result[] && astar_path == dijkstra_path
     result[] = result[] && total_path_weight(time_g, index_to_node_id(time_g, astar_path)) == total_path_weight(time_g, index_to_node_id(time_g, dijkstra_path))


### PR DESCRIPTION
Improved the performance of node Dict generation as part of subgraph generation in `osm_subgraph`. Also tidied up some tests that were throwing warnings about local/global clashes and deprecated use of "highways".